### PR TITLE
애플 소셜 로그인시 보안을 위한 검증을 추가한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/auth/application/AppleVerifier.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/AppleVerifier.java
@@ -10,6 +10,7 @@ import com.nimbusds.jwt.SignedJWT;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @Slf4j
@@ -33,8 +34,9 @@ public class AppleVerifier implements SocialVerifier {
 
             // 2. nonce 검증
             String tokenNonce = claims.getStringClaim("nonce");
-            if (request.originalNonce() != null && !request.originalNonce().equals(tokenNonce)) {
-                log.warn("Invalid nonce: token={}, expected={}", tokenNonce, request.originalNonce());
+            String originalNonce = request.originalNonce();
+            if (!StringUtils.hasText(originalNonce) && !originalNonce.equals(tokenNonce)) {
+                log.warn("Invalid nonce: token={}, expected={}", tokenNonce, originalNonce);
                 throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
             }
 

--- a/src/main/java/akuma/whiplash/domains/auth/application/GoogleVerifier.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/GoogleVerifier.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.domains.auth.application;
 
 import akuma.whiplash.domains.auth.application.dto.etc.SocialMemberInfo;
+import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 import akuma.whiplash.domains.member.domain.contants.SocialType;
 import akuma.whiplash.global.exception.ApplicationException;
 import akuma.whiplash.global.response.code.CommonErrorCode;
@@ -29,9 +30,9 @@ public class GoogleVerifier implements SocialVerifier{
 
 
     @Override
-    public SocialMemberInfo verify(String idTokenString) {
+    public SocialMemberInfo verify(SocialLoginRequest request) {
         try {
-            GoogleIdToken idToken = verifier.verify(idTokenString);
+            GoogleIdToken idToken = verifier.verify(request.token());
             if (idToken == null) {
                 log.warn("Google idToken verification failed");
                 throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
@@ -40,10 +41,9 @@ public class GoogleVerifier implements SocialVerifier{
             GoogleIdToken.Payload payload = idToken.getPayload();
 
             return SocialMemberInfo.builder()
-                .socialId(payload.getSubject())
+                .socialId(SocialType.GOOGLE + "_" + payload.getSubject())
                 .email(payload.getEmail())
                 .name((String) payload.get("name"))
-                .socialType(SocialType.GOOGLE)
                 .build();
         } catch (Exception e) {
             log.warn("Google idToken verification failed", e);

--- a/src/main/java/akuma/whiplash/domains/auth/application/KakaoVerifier.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/KakaoVerifier.java
@@ -2,6 +2,7 @@ package akuma.whiplash.domains.auth.application;
 
 import akuma.whiplash.domains.auth.application.dto.etc.KakaoUserInfo;
 import akuma.whiplash.domains.auth.application.dto.etc.SocialMemberInfo;
+import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 import akuma.whiplash.domains.member.domain.contants.SocialType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,18 +15,16 @@ public class KakaoVerifier implements SocialVerifier {
     private final WebClient webClient;
 
     @Override
-    public SocialMemberInfo verify(String accessToken) {
+    public SocialMemberInfo verify(SocialLoginRequest request) {
         KakaoUserInfo response = webClient.get()
             .uri("https://kapi.kakao.com/v2/user/me") // baseUrl 사용하지 않아도 됨
-            .headers(h -> h.setBearerAuth(accessToken))
+            .headers(h -> h.setBearerAuth(request.token()))
             .retrieve()
             .bodyToMono(KakaoUserInfo.class)
             .block();
 
-
         return SocialMemberInfo.builder()
-            .socialId(String.valueOf(response.id()))
-            .socialType(SocialType.KAKAO)
+            .socialId(SocialType.KAKAO.name() + "_" + String.valueOf(response.id()))
             .email(response.kakaoAccount().email())
             .name(response.properties().nickname())
             .build();

--- a/src/main/java/akuma/whiplash/domains/auth/application/SocialVerifier.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/SocialVerifier.java
@@ -1,8 +1,9 @@
 package akuma.whiplash.domains.auth.application;
 
 import akuma.whiplash.domains.auth.application.dto.etc.SocialMemberInfo;
+import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 
 public interface SocialVerifier {
 
-    SocialMemberInfo verify(String token);
+    SocialMemberInfo verify(SocialLoginRequest request);
 }

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/etc/SocialMemberInfo.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/etc/SocialMemberInfo.java
@@ -5,10 +5,9 @@ import lombok.Builder;
 
 @Builder
 public record SocialMemberInfo (
-    String socialId,    // Google UID
+    String socialId,    // 플랫폼_ID(ex: KAKAO_2y8dnbk33dd)
     String email,
-    String name,
-    SocialType socialType    // "GOOGLE", "APPLE", "KAKAO"
+    String name
 ) {
 
 }

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/request/SocialLoginRequest.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/request/SocialLoginRequest.java
@@ -17,5 +17,8 @@ public record SocialLoginRequest(
 
     @Schema(description = "디바이스 ID", example = "dsjk23121m3")
     @NotBlank(message = "디바이스 ID를 입력해주세요")
-    String deviceId
+    String deviceId,
+
+    @Schema(description = "nonce 암호화 하기 전 raw값(애플 로그인시에만 필요)")
+    String originalNonce
 ) {}

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/response/LoginResponse.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/response/LoginResponse.java
@@ -3,7 +3,7 @@ package akuma.whiplash.domains.auth.application.dto.response;
 import lombok.Builder;
 
 @Builder
-public record AuthResponse (
+public record LoginResponse(
     String accessToken,
     String refreshToken,
     String nickname

--- a/src/main/java/akuma/whiplash/domains/auth/application/mapper/AuthMapper.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/mapper/AuthMapper.java
@@ -11,7 +11,6 @@ public class AuthMapper {
     public static MemberEntity toMemberEntity(SocialMemberInfo memberInfo) {
         return MemberEntity.builder()
             .socialId(memberInfo.socialId())
-            .socialType(memberInfo.socialType())
             .email(memberInfo.email())
             .nickname(memberInfo.name())
             .role(Role.USER)

--- a/src/main/java/akuma/whiplash/domains/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/usecase/AuthUseCase.java
@@ -1,9 +1,8 @@
 package akuma.whiplash.domains.auth.application.usecase;
 
 import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
-import akuma.whiplash.domains.auth.application.dto.response.AuthResponse;
-import akuma.whiplash.domains.auth.domain.service.SocialLoginService;
-import akuma.whiplash.domains.member.domain.contants.SocialType;
+import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
+import akuma.whiplash.domains.auth.domain.service.AuthCommandServiceImpl;
 import akuma.whiplash.global.annotation.architecture.UseCase;
 import lombok.RequiredArgsConstructor;
 
@@ -11,13 +10,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthUseCase {
 
-    private final SocialLoginService socialLoginService;
+    private final AuthCommandServiceImpl authCommandServiceImpl;
 
-    public AuthResponse socialLogin(SocialLoginRequest request) {
-        return socialLoginService.login(
-            SocialType.valueOf(request.socialType()),
-            request.token(),
-            request.deviceId()
-        );
+    public LoginResponse socialLogin(SocialLoginRequest request) {
+        return authCommandServiceImpl.login(request);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandService.java
@@ -1,0 +1,9 @@
+package akuma.whiplash.domains.auth.domain.service;
+
+import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
+import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
+
+public interface AuthCommandService {
+
+    LoginResponse login(SocialLoginRequest request);
+}

--- a/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandServiceImpl.java
@@ -6,14 +6,13 @@ import akuma.whiplash.domains.auth.application.AppleVerifier;
 import akuma.whiplash.domains.auth.application.GoogleVerifier;
 import akuma.whiplash.domains.auth.application.KakaoVerifier;
 import akuma.whiplash.domains.auth.application.dto.etc.SocialMemberInfo;
-import akuma.whiplash.domains.auth.application.dto.response.AuthResponse;
+import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
+import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
 import akuma.whiplash.domains.auth.application.mapper.AuthMapper;
-import akuma.whiplash.domains.member.domain.contants.SocialType;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
 import akuma.whiplash.global.exception.ApplicationException;
-import akuma.whiplash.global.response.code.CommonErrorCode;
 import akuma.whiplash.infrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class SocialLoginService {
+public class AuthCommandServiceImpl implements AuthCommandService {
 
     private final GoogleVerifier googleVerifier;
     private final KakaoVerifier kakaoVerifier;
@@ -31,16 +30,17 @@ public class SocialLoginService {
     private final RedisRepository redisRepository;
     private final JwtProvider jwtProvider;
 
-    public AuthResponse login(SocialType socialType, String token, String deviceId) {
-        SocialMemberInfo socialMemberInfo = switch (socialType) {
-            case GOOGLE -> googleVerifier.verify(token);
-            case APPLE -> appleVerifier.verify(token);
-            case KAKAO -> kakaoVerifier.verify(token);
+    @Override
+    public LoginResponse login(SocialLoginRequest request) {
+        SocialMemberInfo socialMemberInfo = switch (request.socialType()) {
+            case "GOOGLE" -> googleVerifier.verify(request);
+            case "APPLE" -> appleVerifier.verify(request);
+            case "KAKAO" -> kakaoVerifier.verify(request);
             default -> throw ApplicationException.from(BAD_REQUEST);
         };
 
         // DB에서 사용자 조회 or 신규 가입
-        MemberEntity member = memberRepository.findBySocialIdAndSocialType(socialMemberInfo.socialId(), socialMemberInfo.socialType())
+        MemberEntity member = memberRepository.findBySocialId(socialMemberInfo.socialId())
                 .orElseGet(() -> memberRepository.save(
                     AuthMapper.toMemberEntity(socialMemberInfo)
                 ));
@@ -49,14 +49,14 @@ public class SocialLoginService {
         // 다른 디바이스 ID로 리프레시 토큰 존재할 시 기존 리프레시 토큰 삭제
         redisRepository.getKeys("REFRESH:" + member.getId() + ":*")
             .stream()
-            .filter(key -> !key.endsWith(deviceId))
+            .filter(key -> !key.endsWith(request.deviceId()))
             .findFirst().ifPresent(redisRepository::deleteValues);
 
         // JWT 생성
         String accessToken = jwtProvider.generateAccessToken(member.getId(), member.getRole());
-        String refreshToken = jwtProvider.generateRefreshToken(member.getId(), deviceId, member.getRole());
+        String refreshToken = jwtProvider.generateRefreshToken(member.getId(), request.deviceId(), member.getRole());
 
-        return AuthResponse.builder()
+        return LoginResponse.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken)
             .nickname(member.getNickname())

--- a/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
+++ b/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
@@ -3,12 +3,10 @@ package akuma.whiplash.domains.auth.presentation;
 import static akuma.whiplash.global.response.code.CommonErrorCode.*;
 
 import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
-import akuma.whiplash.domains.auth.application.dto.response.AuthResponse;
+import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
 import akuma.whiplash.domains.auth.application.usecase.AuthUseCase;
-import akuma.whiplash.domains.auth.domain.service.SocialLoginService;
 import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
-import akuma.whiplash.global.response.code.CommonErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +25,8 @@ public class AuthController {
     @CustomErrorCodes(commonErrorCodes = {BAD_REQUEST})
     @Operation(summary = "소셜 로그인", description = "구글, 애플, 카카오 소셜 로그인을 지원합니다.")
     @PostMapping("/social-login")
-    public ApplicationResponse<AuthResponse> login(@RequestBody @Valid SocialLoginRequest request) {
-        AuthResponse response = authUseCase.socialLogin(request);
+    public ApplicationResponse<LoginResponse> login(@RequestBody @Valid SocialLoginRequest request) {
+        LoginResponse response = authUseCase.socialLogin(request);
         return ApplicationResponse.onSuccess(response);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/member/persistence/entity/MemberEntity.java
+++ b/src/main/java/akuma/whiplash/domains/member/persistence/entity/MemberEntity.java
@@ -35,10 +35,6 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(name = "social_id", nullable = false)
     private String socialId;
 
-    @Column(name = "social_type")
-    @Enumerated(EnumType.STRING)
-    private SocialType socialType;
-
     @Column(length = 50, nullable = false)
     private String email;
 

--- a/src/main/java/akuma/whiplash/domains/member/persistence/repository/MemberRepository.java
+++ b/src/main/java/akuma/whiplash/domains/member/persistence/repository/MemberRepository.java
@@ -1,11 +1,10 @@
 package akuma.whiplash.domains.member.persistence.repository;
 
-import akuma.whiplash.domains.member.domain.contants.SocialType;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
-    Optional<MemberEntity> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+    Optional<MemberEntity> findBySocialId(String socialId);
 }


### PR DESCRIPTION
## 📄 PR 요약
> 애플 소셜 로그인시 보안을 위한 검증을 추가한다.

## ✍🏻 PR 상세
1. 애플 로그인시 nonce 검증 추가
2. Auth 도메인 Serivice 계층 인터페이스 기반으로 변경
3. member 테이블 social_type 컬럼 삭제(social_id의 prefix로 social_type을 붙이기로 결정)

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #9 