### PR TITLE
토큰 재발급 기능을 구현한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/etc/MemberContext.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/etc/MemberContext.java
@@ -1,9 +1,11 @@
 package akuma.whiplash.domains.auth.application.dto.etc;
 
+import akuma.whiplash.domains.member.domain.contants.Role;
 import lombok.Builder;
 
 @Builder
 public record MemberContext(
+    Role role,
     Long memberId,
     String socialId,
     String email,

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/request/ReissueRequest.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/request/ReissueRequest.java
@@ -1,0 +1,14 @@
+package akuma.whiplash.domains.auth.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(name = "토큰 재발급 DTO")
+public record ReissueRequest(
+
+    @Schema(name = "디바이스 ID")
+    @NotBlank(message = "디바이스 ID를 입력해주세요.")
+    String deviceId
+) {
+
+}

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/response/TokenResponse.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package akuma.whiplash.domains.auth.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/src/main/java/akuma/whiplash/domains/auth/application/mapper/AuthMapper.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/mapper/AuthMapper.java
@@ -20,6 +20,7 @@ public class AuthMapper {
 
     public static MemberContext mapToMemberContext(MemberEntity memberEntity) {
         return MemberContext.builder()
+            .role(memberEntity.getRole())
             .memberId(memberEntity.getId())
             .socialId(memberEntity.getSocialId())
             .email(memberEntity.getEmail())

--- a/src/main/java/akuma/whiplash/domains/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/usecase/AuthUseCase.java
@@ -1,10 +1,13 @@
 package akuma.whiplash.domains.auth.application.usecase;
 
+import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
 import akuma.whiplash.domains.auth.application.dto.request.LogoutRequest;
 import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
+import akuma.whiplash.domains.auth.application.dto.response.TokenResponse;
 import akuma.whiplash.domains.auth.domain.service.AuthCommandService;
 import akuma.whiplash.global.annotation.architecture.UseCase;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -19,5 +22,9 @@ public class AuthUseCase {
 
     public void logout(LogoutRequest request, Long memberId) {
         authCommandService.logout(request, memberId);
+    }
+
+    public TokenResponse reissueToken(String refreshToken, MemberContext memberContext, String deviceId) {
+        return authCommandService.reissueToken(refreshToken, memberContext, deviceId);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/auth/domain/service/AuthCommandService.java
@@ -1,11 +1,15 @@
 package akuma.whiplash.domains.auth.domain.service;
 
+import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
 import akuma.whiplash.domains.auth.application.dto.request.LogoutRequest;
 import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
+import akuma.whiplash.domains.auth.application.dto.response.TokenResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthCommandService {
 
     LoginResponse login(SocialLoginRequest request);
     void logout(LogoutRequest request, Long memberId);
+    TokenResponse reissueToken(String oldRefreshToken, MemberContext memberContext, String deviceId);
 }

--- a/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
+++ b/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
@@ -4,12 +4,15 @@ import static akuma.whiplash.global.response.code.CommonErrorCode.*;
 
 import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
 import akuma.whiplash.domains.auth.application.dto.request.LogoutRequest;
+import akuma.whiplash.domains.auth.application.dto.request.ReissueRequest;
 import akuma.whiplash.domains.auth.application.dto.request.SocialLoginRequest;
 import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
+import akuma.whiplash.domains.auth.application.dto.response.TokenResponse;
 import akuma.whiplash.domains.auth.application.usecase.AuthUseCase;
 import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -39,5 +42,14 @@ public class AuthController {
     public ApplicationResponse<Void> logout(@AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid LogoutRequest request) {
         authUseCase.logout(request, memberContext.memberId());
         return ApplicationResponse.onSuccess();
+    }
+
+    @CustomErrorCodes(commonErrorCodes = {BAD_REQUEST})
+    @Operation(summary = "토큰 재발급", description = "액세스, 리프레시 토큰을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ApplicationResponse<TokenResponse> reissueToken(HttpServletRequest request, @AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid ReissueRequest reissueRequest) {
+        String refreshToken = request.getHeader("Authorization").split(" ")[1];
+        TokenResponse tokenResponse = authUseCase.reissueToken(refreshToken, memberContext, reissueRequest.deviceId());
+        return ApplicationResponse.onSuccess(tokenResponse);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
+++ b/src/main/java/akuma/whiplash/domains/auth/presentation/AuthController.java
@@ -10,17 +10,20 @@ import akuma.whiplash.domains.auth.application.dto.response.LoginResponse;
 import akuma.whiplash.domains.auth.application.dto.response.TokenResponse;
 import akuma.whiplash.domains.auth.application.usecase.AuthUseCase;
 import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
+import akuma.whiplash.global.exception.ApplicationException;
 import akuma.whiplash.global.response.ApplicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -48,7 +51,15 @@ public class AuthController {
     @Operation(summary = "토큰 재발급", description = "액세스, 리프레시 토큰을 재발급합니다.")
     @PostMapping("/reissue")
     public ApplicationResponse<TokenResponse> reissueToken(HttpServletRequest request, @AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid ReissueRequest reissueRequest) {
-        String refreshToken = request.getHeader("Authorization").split(" ")[1];
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("authHeader is not valid, authHeader={}", authHeader);
+            throw ApplicationException.from(BAD_REQUEST);
+        }
+
+        String refreshToken = authHeader.substring("Bearer ".length());
+
         TokenResponse tokenResponse = authUseCase.reissueToken(refreshToken, memberContext, reissueRequest.deviceId());
         return ApplicationResponse.onSuccess(tokenResponse);
     }

--- a/src/main/java/akuma/whiplash/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/akuma/whiplash/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null) {
             log.info("토큰 함께 요청 : {}", token);
             try {
-                if (request.getRequestURI().contains("/refresh")) {
+                if (request.getRequestURI().contains("/reissue")) {
                     log.info("재발급 진행");
                     jwtUtils.validateToken(response, token, REFRESH);
                 } else {

--- a/src/main/java/akuma/whiplash/global/config/security/jwt/JwtUtils.java
+++ b/src/main/java/akuma/whiplash/global/config/security/jwt/JwtUtils.java
@@ -66,8 +66,7 @@ public class JwtUtils {
         }
     }
 
-    public void validateRefreshToken(Long memberId, String deviceId, HttpServletRequest request) {
-        String refreshToken = request.getHeader(AUTHORIZATION).split(" ")[1];
+    public void validateRefreshToken(String refreshToken, Long memberId, String deviceId) {
         String redisToken = redisRepository
             .getValues(REFRESH.toString() + ":" + memberId + ":" + deviceId)
             .orElseThrow(() -> ApplicationException.from(TOKEN_NOT_FOUND));


### PR DESCRIPTION
## 📄 PR 요약
> 토큰 재발급 기능을 구현한다.

## ✍🏻 PR 상세
1. 토큰 재발급 API 구현
->RTR 기법을 이용해 액세스, 리프레시 토큰 모두 재발급하도록 구현했습니다.

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new POST endpoint for token reissuance, allowing users to obtain new access and refresh tokens.
  * Introduced request and response structures for token reissue, including validation and documentation support.
* **Improvements**
  * Enhanced member context to include user role information.
  * Updated token validation logic for improved clarity and directness in handling refresh tokens.
* **Bug Fixes**
  * Adjusted authentication filter to correctly handle token reissuance requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->