### PR TITLE
알람 삭제 기능을 구현한다.

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -40,11 +40,12 @@ jobs:
         id: vars
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      # 6. env.properties 생성
+      # 6. env.properties 생성, google.json base64 디코딩
       - name: Generate env.properties
         run: |
           mkdir -p src/main/resources
           echo "${{ secrets.DEV_ENV_PROPERTIES }}" > src/main/resources/env.properties
+          echo "${{ secrets.GOOGLE_JSON }}" | base64 -d > src/main/resources/google.json
 
       # 7. 빌드
       - name: Build JAR

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -40,11 +40,12 @@ jobs:
 #      - name: Run tests
 #        run: ./gradlew test --no-daemon
 
-      # 6. env.properties 생성
+      # 6. env.properties 생성, google.json base64 디코딩
       - name: Generate env.properties
         run: |
           mkdir -p src/main/resources
           echo "${{ secrets.DEV_ENV_PROPERTIES }}" > src/main/resources/env.properties
+          echo "${{ secrets.GOOGLE_JSON }}" | base64 -d > src/main/resources/google.json
 
       # 7. 빌드
       - name: Build JAR

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 env.properties
 env-test.properties
+google.json

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,13 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
 
 	// Google OAuth
-	implementation 'com.google.api-client:google-api-client:2.4.1'
+	implementation 'com.google.api-client:google-api-client:1.34.1'
 	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
 	implementation 'com.google.oauth-client:google-oauth-client:1.34.1'
+
+	// Google Sheets
+	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
+	implementation 'com.google.apis:google-api-services-sheets:v4-rev612-1.25.0'
 
 	// WebFlux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux:3.5.3'

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/RemoveAlarmRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/RemoveAlarmRequest.java
@@ -1,0 +1,13 @@
+package akuma.whiplash.domains.alarm.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "알람 삭제 요청 DTO")
+public record RemoveAlarmRequest(
+
+    @Schema(description = "알람 삭제 이유", example = "알람이 너무 자주 울려서요.")
+    @NotBlank(message = "알람 삭제 이유를 입력해주세요")
+    String reason
+) {
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
@@ -30,6 +30,11 @@ public class AlarmUseCase {
         return alarmCommandService.alarmOff(memberId, alarmId, clientNow);
     }
 
+    public void removeAlarm(Long memberId, Long alarmId, String reason) {
+        alarmCommandService.removeAlarm(memberId, alarmId, reason);
+    }
+
+
     public List<AlarmInfoPreviewResponse> getAlarms(Long memberId) {
         return alarmQueryService.getAlarms(memberId);
     }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandService.java
@@ -10,4 +10,5 @@ public interface AlarmCommandService {
     void createAlarm(RegisterAlarmRequest request, Long memberId);
     CreateAlarmOccurrenceResponse createAlarmOccurrence(Long memberId, Long alarmId);
     AlarmOffResultResponse alarmOff(Long memberId, Long alarmId, LocalDateTime clientNow);
+    void removeAlarm(Long memberId, Long alarmId, String reason);
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
@@ -15,6 +15,7 @@ public enum AlarmErrorCode implements BaseErrorCode {
     ALARM_OFF_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "ALARM_004", "잔여 알람 끄기 횟수가 부족합니다."),
     REPEAT_DAYS_NOT_CONFIG(HttpStatus.BAD_REQUEST, "ALARM_005", "반복 요일이 설정되지 않았습니다."),
     INVALID_CLIENT_DATE(HttpStatus.BAD_REQUEST, "ALARM_006", "요청의 날짜가 서버 기준 날짜와 일치하지 않습니다."),
+    ALARM_DELETE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "ALARM_007", "지금은 알람을 삭제할 수 없습니다."),
 
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM_401", "존재하지 않는 알람입니다.")
     ;

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
@@ -3,6 +3,7 @@ package akuma.whiplash.domains.alarm.persistence.repository;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivateType;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,6 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     Optional<AlarmOccurrenceEntity> findTopByAlarmIdAndDeactivateTypeOrderByDateDesc(
         Long alarmId, DeactivateType deactivateType
     );
+    List<AlarmOccurrenceEntity> findAllByAlarmId(Long alarmId);
+    void deleteAllByAlarmId(Long alarmId);
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOffLogRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOffLogRepository.java
@@ -11,4 +11,5 @@ public interface AlarmOffLogRepository extends JpaRepository<AlarmOffLogEntity, 
         LocalDateTime start,
         LocalDateTime end
     );
+    void deleteAllByAlarmId(Long alarmId);
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRingingLogRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRingingLogRepository.java
@@ -1,0 +1,8 @@
+package akuma.whiplash.domains.alarm.persistence.repository;
+
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmRingingLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRingingLogRepository extends JpaRepository<AlarmRingingLogEntity, Long> {
+    void deleteAllByAlarmOccurrenceId(Long alarmOccurrenceId);
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -5,6 +5,7 @@ import static akuma.whiplash.domains.auth.exception.AuthErrorCode.*;
 import static akuma.whiplash.domains.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmOffRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.RemoveAlarmRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.RegisterAlarmRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmInfoPreviewResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmOffResultResponse;
@@ -19,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,6 +66,22 @@ public class AlarmController {
         AlarmOffResultResponse response = alarmUseCase.alarmOff(memberContext.memberId(), alarmId, request.clientNow());
         return ApplicationResponse.onSuccess(response);
     }
+
+    @CustomErrorCodes(
+        alarmErrorCodes = {ALARM_NOT_FOUND, ALARM_DELETE_NOT_AVAILABLE},
+        authErrorCodes = {PERMISSION_DENIED}
+    )
+    @Operation(summary = "알람 삭제", description = "알람을 삭제합니다.")
+    @DeleteMapping("/{alarmId}")
+    public ApplicationResponse<Void> removeAlarm(
+        @AuthenticationPrincipal MemberContext memberContext,
+        @PathVariable Long alarmId,
+        @RequestBody @Valid RemoveAlarmRequest request
+    ) {
+        alarmUseCase.removeAlarm(memberContext.memberId(), alarmId, request.reason());
+        return ApplicationResponse.onSuccess();
+    }
+
 
     @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
     @Operation(summary = "알람 목록 조회", description = "사용자가 등록한 알람 목록을 조회합니다.")

--- a/src/main/resources/oauth.yml
+++ b/src/main/resources/oauth.yml
@@ -1,6 +1,11 @@
 oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
+    sheet:
+      id: ${GOOGLE_SHEET_ID}
+      credentials-path: ${GOOGLE_SHEET_CREDENTIALS}
+      range: "알람 삭제 이유!A:C"
+
   apple:
     client-id: ${APPLE_CLIENT_ID}
 #  kakao:


### PR DESCRIPTION
## 📄 PR 요약
> 알람 삭제 기능을 구현한다.

## ✍🏻 PR 상세
1. 알람 삭제 API 구현
- 구글 스프레드 시트 연동, 삭제 사유를 Google Sheets에 로그로 기록
- 알람 삭제시 alarm_occurrence, alarm_ringing_log, alarm_off_log 모두 삭제

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #29 