### PR TITLE
알람 끄기 잔여 횟수를 조회하는 API를 분리한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmInfoPreviewResponse.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmInfoPreviewResponse.java
@@ -46,9 +46,6 @@ public record AlarmInfoPreviewResponse(
     LocalDate secondUpcomingDay,
 
     @Schema(description = "그 다음 텀의 알람 요일", example = "목요일")
-    String secondUpcomingDayOfWeek,
-
-    @Schema(description = "회원의 남은 알람 끄기 횟수(회원당 매주 2회 부여, 매주 월요일 초기화)", example = "1")
-    Long remainingOffCount
+    String secondUpcomingDayOfWeek
 
 ) {}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmRemainingOffCountResponse.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmRemainingOffCountResponse.java
@@ -1,0 +1,14 @@
+package akuma.whiplash.domains.alarm.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "남은 알람 끄기 횟수 응답")
+public record AlarmRemainingOffCountResponse(
+    @Schema(
+        description = "회원의 남은 알람 끄기 횟수(회원당 매주 2회 부여, 매주 월요일 초기화)",
+        example = "1"
+    )
+    Long remainingOffCount
+) {}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
@@ -4,6 +4,7 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmInfoPreviewResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmOffResultResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmRemainingOffCountResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
 import akuma.whiplash.domains.alarm.domain.service.AlarmCommandService;
 import akuma.whiplash.domains.alarm.domain.service.AlarmQueryService;
@@ -41,5 +42,9 @@ public class AlarmUseCase {
 
     public List<AlarmInfoPreviewResponse> getAlarms(Long memberId) {
         return alarmQueryService.getAlarms(memberId);
+    }
+
+    public AlarmRemainingOffCountResponse getRemainingOffCount(Long memberId) {
+        return alarmQueryService.getRemainingOffCount(memberId);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryService.java
@@ -2,10 +2,12 @@ package akuma.whiplash.domains.alarm.domain.service;
 
 import akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmInfoPreviewResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmRemainingOffCountResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface AlarmQueryService {
     List<AlarmInfoPreviewResponse> getAlarms(Long memberId);
     List<OccurrencePushInfo> getPreNotificationTargets(LocalDateTime startInclusive, LocalDateTime endInclusive);
+    AlarmRemainingOffCountResponse getRemainingOffCount(Long memberId);
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -10,6 +10,7 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmRemoveRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmInfoPreviewResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmOffResultResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmRemainingOffCountResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.usecase.AlarmUseCase;
 import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
@@ -104,5 +105,15 @@ public class AlarmController {
     public ApplicationResponse<List<AlarmInfoPreviewResponse>> getAlarms(@AuthenticationPrincipal MemberContext memberContext) {
         List<AlarmInfoPreviewResponse> alarms = alarmUseCase.getAlarms(memberContext.memberId());
         return ApplicationResponse.onSuccess(alarms);
+    }
+
+    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
+    @Operation(summary = "남은 알람 끄기 횟수 조회", description = "회원의 이번 주 남은 알람 끄기 횟수를 조회합니다.")
+    @GetMapping("/off-count")
+    public ApplicationResponse<AlarmRemainingOffCountResponse> getRemainingOffCount(
+        @AuthenticationPrincipal MemberContext memberContext
+    ) {
+        AlarmRemainingOffCountResponse response = alarmUseCase.getRemainingOffCount(memberContext.memberId());
+        return ApplicationResponse.onSuccess(response);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/auth/application/dto/request/RegisterFcmTokenRequest.java
+++ b/src/main/java/akuma/whiplash/domains/auth/application/dto/request/RegisterFcmTokenRequest.java
@@ -7,6 +7,6 @@ import jakarta.validation.constraints.NotBlank;
 public record RegisterFcmTokenRequest(
 
     @Schema(description = "FCM 토큰", example = "djkhsa01whjas")
-    @NotBlank
+    @NotBlank(message = "FCM 토큰을 입력해주세요.")
     String fcmToken
 ) {}


### PR DESCRIPTION
## 📄 PR 요약
> 알람 끄기 잔여 횟수를 조회하는 API를 분리한다.

## ✍🏻 PR 상세
1. 알람 끄기 잔여 횟수를 조회하는 API를 분리
- `GET /api/alarms` 에서 remaingOffCount 제거
- `GET /api/alarms/off-count` 구현

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #47 