### PR TITLE
약관 동의 API를 분리한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPrivacyPolicyModifyRequest.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPrivacyPolicyModifyRequest.java
@@ -1,15 +1,13 @@
 package akuma.whiplash.domains.member.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
-public record MemberTermsModifyRequest(
+public record MemberPrivacyPolicyModifyRequest(
     @Schema(description = "개인정보 수집 동의 여부")
-    Boolean privacyPolicy,
-
-    @Schema(description = "푸시 알림 수신 동의 여부")
-    Boolean pushNotificationPolicy
+    @NotNull(message = "개인정보 수집 동의 여부를 선택해주세요.")
+    Boolean privacyPolicy
 ) {
-
 }

--- a/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPrivacyPolicyModifyRequest.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPrivacyPolicyModifyRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record MemberPrivacyPolicyModifyRequest(
-    @Schema(description = "개인정보 수집 동의 여부")
+    @Schema(description = "개인정보 수집 동의 여부", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "개인정보 수집 동의 여부를 선택해주세요.")
     Boolean privacyPolicy
 ) {

--- a/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPushNotificationPolicyModifyRequest.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPushNotificationPolicyModifyRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record MemberPushNotificationPolicyModifyRequest(
-    @Schema(description = "푸시 알림 수신 동의 여부")
+    @Schema(description = "푸시 알림 수신 동의 여부", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "푸시 알림 수신 동의 여부를 선택해주세요.")
     Boolean pushNotificationPolicy
 ) {

--- a/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPushNotificationPolicyModifyRequest.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/dto/request/MemberPushNotificationPolicyModifyRequest.java
@@ -1,0 +1,14 @@
+package akuma.whiplash.domains.member.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record MemberPushNotificationPolicyModifyRequest(
+    @Schema(description = "푸시 알림 수신 동의 여부")
+    @NotNull(message = "푸시 알림 수신 동의 여부를 선택해주세요.")
+    Boolean pushNotificationPolicy
+) {
+
+}

--- a/src/main/java/akuma/whiplash/domains/member/application/usecase/MemberUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/usecase/MemberUseCase.java
@@ -1,5 +1,6 @@
 package akuma.whiplash.domains.member.application.usecase;
 
+import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
 import akuma.whiplash.domains.member.application.dto.request.MemberPrivacyPolicyModifyRequest;
 import akuma.whiplash.domains.member.application.dto.request.MemberPushNotificationPolicyModifyRequest;
 import akuma.whiplash.domains.member.domain.service.MemberCommandService;
@@ -21,7 +22,7 @@ public class MemberUseCase {
         memberCommandService.modifyPushNotificationPolicy(memberId, request.pushNotificationPolicy());
     }
 
-    public void hardDeleteMember(Long memberId) {
-        memberCommandService.hardDeleteMember(memberId);
+    public void hardDeleteMember(MemberContext memberContext) {
+        memberCommandService.hardDeleteMember(memberContext.memberId(), memberContext.deviceId());
     }
 }

--- a/src/main/java/akuma/whiplash/domains/member/application/usecase/MemberUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/member/application/usecase/MemberUseCase.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.domains.member.application.usecase;
 
-import akuma.whiplash.domains.member.application.dto.request.MemberTermsModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPrivacyPolicyModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPushNotificationPolicyModifyRequest;
 import akuma.whiplash.domains.member.domain.service.MemberCommandService;
 import akuma.whiplash.global.annotation.architecture.UseCase;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,12 @@ public class MemberUseCase {
 
     private final MemberCommandService memberCommandService;
 
-    public void modifyMemberTermsInfo(Long memberId, MemberTermsModifyRequest request) {
-        memberCommandService.modifyMemberTermsInfo(memberId, request);
+    public void modifyMemberPrivacyPolicy(Long memberId, MemberPrivacyPolicyModifyRequest request) {
+        memberCommandService.modifyPrivacyPolicy(memberId, request.privacyPolicy());
+    }
+
+    public void modifyMemberPushNotificationPolicy(Long memberId, MemberPushNotificationPolicyModifyRequest request) {
+        memberCommandService.modifyPushNotificationPolicy(memberId, request.pushNotificationPolicy());
     }
 
     public void hardDeleteMember(Long memberId) {

--- a/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandService.java
@@ -1,8 +1,7 @@
 package akuma.whiplash.domains.member.domain.service;
 
-
 public interface MemberCommandService {
-    void modifyPrivacyPolicy(Long memberId, Boolean privacyPolicy);
-    void modifyPushNotificationPolicy(Long memberId, Boolean pushNotificationPolicy);
-    void hardDeleteMember(Long memberId);
+    void modifyPrivacyPolicy(Long memberId, boolean privacyPolicy);
+    void modifyPushNotificationPolicy(Long memberId, boolean pushNotificationPolicy);
+    void hardDeleteMember(Long memberId, String deviceId);
 }

--- a/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandService.java
@@ -1,8 +1,8 @@
 package akuma.whiplash.domains.member.domain.service;
 
-import akuma.whiplash.domains.member.application.dto.request.MemberTermsModifyRequest;
 
 public interface MemberCommandService {
-    void modifyMemberTermsInfo(Long memberId, MemberTermsModifyRequest request);
+    void modifyPrivacyPolicy(Long memberId, Boolean privacyPolicy);
+    void modifyPushNotificationPolicy(Long memberId, Boolean pushNotificationPolicy);
     void hardDeleteMember(Long memberId);
 }

--- a/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandServiceImpl.java
@@ -4,7 +4,8 @@ import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceReposi
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOffLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRingingLogRepository;
-import akuma.whiplash.domains.member.application.dto.request.MemberTermsModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPrivacyPolicyModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPushNotificationPolicyModifyRequest;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
@@ -25,17 +26,19 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final AlarmRingingLogRepository alarmRingingLogRepository;
 
     @Override
-    public void modifyMemberTermsInfo(Long memberId, MemberTermsModifyRequest request) {
+    public void modifyPrivacyPolicy(Long memberId, Boolean privacyPolicy) {
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> ApplicationException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (request.privacyPolicy() != null) {
-            member.updatePrivacyPolicy(request.privacyPolicy());
-        }
+        member.updatePrivacyPolicy(privacyPolicy);
+    }
 
-        if (request.pushNotificationPolicy() != null) {
-            member.updatePushNotificationPolicy(request.pushNotificationPolicy());
-        }
+    @Override
+    public void modifyPushNotificationPolicy(Long memberId, Boolean pushNotificationPolicy) {
+        MemberEntity member = memberRepository.findById(memberId)
+            .orElseThrow(() -> ApplicationException.from(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.updatePushNotificationPolicy(pushNotificationPolicy);
     }
 
     @Override

--- a/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/member/domain/service/MemberCommandServiceImpl.java
@@ -4,12 +4,12 @@ import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceReposi
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOffLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRingingLogRepository;
-import akuma.whiplash.domains.member.application.dto.request.MemberPrivacyPolicyModifyRequest;
-import akuma.whiplash.domains.member.application.dto.request.MemberPushNotificationPolicyModifyRequest;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
+import akuma.whiplash.global.config.security.jwt.JwtUtils;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.infrastructure.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,25 +24,31 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final AlarmOccurrenceRepository alarmOccurrenceRepository;
     private final AlarmOffLogRepository alarmOffLogRepository;
     private final AlarmRingingLogRepository alarmRingingLogRepository;
+    private final JwtUtils jwtUtils;
+    private final RedisService redisService;
 
     @Override
-    public void modifyPrivacyPolicy(Long memberId, Boolean privacyPolicy) {
+    public void modifyPrivacyPolicy(Long memberId, boolean privacyPolicy) {
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> ApplicationException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        member.updatePrivacyPolicy(privacyPolicy);
+        if (member.isPrivacyPolicy() != privacyPolicy) {
+            member.updatePrivacyPolicy(privacyPolicy);
+        }
     }
 
     @Override
-    public void modifyPushNotificationPolicy(Long memberId, Boolean pushNotificationPolicy) {
+    public void modifyPushNotificationPolicy(Long memberId, boolean pushNotificationPolicy) {
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> ApplicationException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        member.updatePushNotificationPolicy(pushNotificationPolicy);
+        if (member.isPushNotificationPolicy() != pushNotificationPolicy) {
+            member.updatePushNotificationPolicy(pushNotificationPolicy);
+        }
     }
 
     @Override
-    public void hardDeleteMember(Long memberId) {
+    public void hardDeleteMember(Long memberId, String deviceId) {
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> ApplicationException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -61,7 +67,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 6. member 삭제
         memberRepository.delete(member);
 
-
-        // TODO: 리프레시 토큰, FCM 토큰 삭제
+        // 리프레시 토큰, FCM 토큰 삭제
+        jwtUtils.expireRefreshToken(memberId, deviceId);
+        redisService.removeFcmTokenForDevice(memberId, deviceId);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/member/presentation/MemberController.java
+++ b/src/main/java/akuma/whiplash/domains/member/presentation/MemberController.java
@@ -3,7 +3,8 @@ package akuma.whiplash.domains.member.presentation;
 import static akuma.whiplash.domains.member.exception.MemberErrorCode.*;
 
 import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
-import akuma.whiplash.domains.member.application.dto.request.MemberTermsModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPrivacyPolicyModifyRequest;
+import akuma.whiplash.domains.member.application.dto.request.MemberPushNotificationPolicyModifyRequest;
 import akuma.whiplash.domains.member.application.usecase.MemberUseCase;
 import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
@@ -25,14 +26,22 @@ public class MemberController {
     private final MemberUseCase memberUseCase;
 
     @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
-    @Operation(summary = "회원 약관 동의 정보 변경", description = "개인정보 제공 동의, 푸시 알림 수신 동의 여부를 변경합니다.")
-    @PutMapping("/terms")
-    public ApplicationResponse<Void> modifyMemberTermsInfo(@AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid MemberTermsModifyRequest request) {
-        memberUseCase.modifyMemberTermsInfo(memberContext.memberId(), request);
+    @Operation(summary = "회원 개인정보 수집 동의 변경", description = "개인정보 수집 동의 여부를 변경합니다.")
+    @PutMapping("/terms/privacy")
+    public ApplicationResponse<Void> modifyPrivacyPolicy(@AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid MemberPrivacyPolicyModifyRequest request) {
+        memberUseCase.modifyMemberPrivacyPolicy(memberContext.memberId(), request);
         return ApplicationResponse.onSuccess();
     }
 
-    @CustomErrorCodes
+    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
+    @Operation(summary = "회원 푸시 알림 수신 동의 변경", description = "푸시 알림 수신 동의 여부를 변경합니다.")
+    @PutMapping("/terms/push-notifications")
+    public ApplicationResponse<Void> modifyPushNotificationPolicy(@AuthenticationPrincipal MemberContext memberContext, @RequestBody @Valid MemberPushNotificationPolicyModifyRequest request) {
+        memberUseCase.modifyMemberPushNotificationPolicy(memberContext.memberId(), request);
+        return ApplicationResponse.onSuccess();
+    }
+
+    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
     @Operation(summary = "회원 탈퇴", description = "회원 정보, 관련된 알람 정보를 hard delete 합니다.")
     @DeleteMapping
     public ApplicationResponse<Void> hardDeleteMember(@AuthenticationPrincipal MemberContext memberContext) {

--- a/src/main/java/akuma/whiplash/domains/member/presentation/MemberController.java
+++ b/src/main/java/akuma/whiplash/domains/member/presentation/MemberController.java
@@ -45,7 +45,7 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴", description = "회원 정보, 관련된 알람 정보를 hard delete 합니다.")
     @DeleteMapping
     public ApplicationResponse<Void> hardDeleteMember(@AuthenticationPrincipal MemberContext memberContext) {
-        memberUseCase.hardDeleteMember(memberContext.memberId());
+        memberUseCase.hardDeleteMember(memberContext);
         return ApplicationResponse.onSuccess();
     }
 }


### PR DESCRIPTION
## 📄 PR 요약
> 약관 동의 API를 분리한다.

## ✍🏻 PR 상세
1. 약관 동의 API 분리
- 기존 `PUT /api/members/terms` -> `PUT /api/members/terms/push-notifications`,  `PUT /api/members/terms/privacy` 로 분리

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 개인정보 처리방침 동의 및 푸시 알림 수신 동의 상태를 각각 별도의 엔드포인트에서 개별적으로 수정할 수 있도록 기능이 분리되었습니다.

* **버그 수정**
  * 각 동의 항목에 대해 필수 입력값 검증이 강화되었습니다.

* **문서화**
  * API 문서에 각 동의 항목별 요청 형식이 명확하게 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->