### PR TITLE
푸시 알림 Payload를 변경한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmReminderScheduler.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmReminderScheduler.java
@@ -28,51 +28,53 @@ public class AlarmReminderScheduler {
     // @Scheduled(cron = "0 * * * * *") // 매 분
     public void sendPreAlarmNotifications() {
         log.info("[AlarmReminderScheduler.sendPreAlarmNotifications] 알람 울리기 1시간 전 푸시 알림 전송 스케줄러 시작");
-        // 0. 시간 기준 (분 단위 정렬)
-        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        LocalDateTime windowStart = now.plusMinutes(59);
-        LocalDateTime windowEnd = now.plusMinutes(61);
+        try {
+            // 0. 시간 기준 (분 단위 정렬)
+            LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+            LocalDateTime windowStart = now.plusMinutes(59);
+            LocalDateTime windowEnd = now.plusMinutes(61);
 
-        // 1. DB에서 알림 대상 필터링 (자정 크로스 안전)
-        List<OccurrencePushInfo> infos = alarmQueryService.getPreNotificationTargets(windowStart, windowEnd);
+            // 1. DB에서 알림 대상 필터링 (자정 크로스 안전)
+            List<OccurrencePushInfo> infos = alarmQueryService.getPreNotificationTargets(windowStart, windowEnd);
 
-        if (infos.isEmpty())
-            return;
+            if (infos.isEmpty())
+                return;
 
-        // 2. Redis에서 FCM 토큰 조회 → PushTargetDto 변환
-        List<PushTargetDto> targets = infos.stream()
-            .flatMap(info ->
-                redisService.getFcmTokens(info.memberId()).stream()
-                    .map(token -> PushTargetDto.builder()
-                        .token(token)
-                        .address(info.address())
-                        .memberId(info.memberId())
-                        .occurrenceId(info.occurrenceId())
-                        .build()
-                    )
-            )
-            .toList(); // <-- 여기서 한 번만 호출
+            // 2. Redis에서 FCM 토큰 조회 → PushTargetDto 변환
+            List<PushTargetDto> targets = infos.stream()
+                .flatMap(info ->
+                    redisService.getFcmTokens(info.memberId()).stream()
+                        .map(token -> PushTargetDto.builder()
+                            .token(token)
+                            .address(info.address())
+                            .memberId(info.memberId())
+                            .occurrenceId(info.occurrenceId())
+                            .build()
+                        )
+                )
+                .toList(); // <-- 여기서 한 번만 호출
 
-        if (targets.isEmpty())
-            return;
+            if (targets.isEmpty())
+                return;
 
-        FcmSendResult result = fcmService.sendBulkNotification(targets);
+            FcmSendResult result = fcmService.sendBulkNotification(targets);
 
-        // 3. 성공한 occurrence만 reminderSent=true 벌크 업데이트
-        if (!result.getSuccessOccurrenceIds().isEmpty()) {
-            alarmCommandService.markReminderSent(result.getSuccessOccurrenceIds());
-        }
-
-        // 4. 무효 토큰 정리(멤버 매핑 정보가 있으면 거기서 제거)
-        for (Map.Entry<Long, List<String>> e : result.getMemberToTokens().entrySet()) {
-            Long memberId = e.getKey();
-            for (String bad : result.getInvalidTokens()) {
-                redisService.removeInvalidToken(memberId, bad);
+            // 3. 성공한 occurrence만 reminderSent=true 벌크 업데이트
+            if (!result.getSuccessOccurrenceIds().isEmpty()) {
+                alarmCommandService.markReminderSent(result.getSuccessOccurrenceIds());
             }
+
+            // 4. 무효 토큰 정리(멤버 매핑 정보가 있으면 거기서 제거)
+            for (Map.Entry<Long, List<String>> e : result.getMemberToTokens().entrySet()) {
+                Long memberId = e.getKey();
+                for (String invalidToken : result.getInvalidTokens()) {
+                    redisService.removeInvalidToken(memberId, invalidToken);
+                }
+            }
+
+        } finally {
+            log.info("[AlarmReminderScheduler.sendPreAlarmNotifications] 알람 울리기 1시간 전 푸시 알림 전송 스케줄러 종료");
         }
-
-        log.info("[AlarmReminderScheduler.sendPreAlarmNotifications] 알람 울리기 1시간 전 푸시 알림 전송 스케줄러 종료");
-
     }
 
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmReminderScheduler.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmReminderScheduler.java
@@ -27,6 +27,7 @@ public class AlarmReminderScheduler {
 
     // @Scheduled(cron = "0 * * * * *") // 매 분
     public void sendPreAlarmNotifications() {
+        log.info("[AlarmReminderScheduler.sendPreAlarmNotifications] 알람 울리기 1시간 전 푸시 알림 전송 스케줄러 시작");
         // 0. 시간 기준 (분 단위 정렬)
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
         LocalDateTime windowStart = now.plusMinutes(59);
@@ -69,6 +70,9 @@ public class AlarmReminderScheduler {
                 redisService.removeInvalidToken(memberId, bad);
             }
         }
+
+        log.info("[AlarmReminderScheduler.sendPreAlarmNotifications] 알람 울리기 1시간 전 푸시 알림 전송 스케줄러 종료");
+
     }
 
 }

--- a/src/main/java/akuma/whiplash/infrastructure/firebase/FcmService.java
+++ b/src/main/java/akuma/whiplash/infrastructure/firebase/FcmService.java
@@ -1,7 +1,6 @@
 package akuma.whiplash.infrastructure.firebase;
 
 import akuma.whiplash.domains.alarm.application.dto.etc.PushTargetDto;
-import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.infrastructure.firebase.dto.FcmSendResult;
 import akuma.whiplash.infrastructure.redis.RedisService;
 import com.google.firebase.messaging.AndroidConfig;
@@ -12,7 +11,6 @@ import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.SendResponse;
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
## 📄 PR 요약
> 푸시 알림 Payload를 변경한다.

## ✍🏻 PR 상세
1. 푸시 알림 Payload를 변경
- 기존 notification 제거, data.title, data.body 추가

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 푸시 전송 로직 개선: 본문별 묶음·토큰 중복제거로 대량 배치 전송(최대 500개) 지원, 데이터 페이로드(title/body) 전환, Android/iOS 플랫폼 전송 우선순위·실시간성 최적화, 전송 결과 집계 및 무효 토큰 처리 강화
- Chores
  - 알림 예약 작업에 시작/종료 로그 추가로 모니터링 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->