### PR TITLE
[#0] 🐛 Fix: suppress logging for @NoMethodLog

### DIFF
--- a/src/main/java/akuma/whiplash/global/log/MethodLoggingAspect.java
+++ b/src/main/java/akuma/whiplash/global/log/MethodLoggingAspect.java
@@ -1,11 +1,9 @@
 package akuma.whiplash.global.log;
 
 import static akuma.whiplash.global.log.LogConst.MDC_REQUEST_ID_KEY;
-import akuma.whiplash.global.log.MethodLogSuppressor; 
-import akuma.whiplash.global.log.NoMethodLog;         
-
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -15,10 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.MDC;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import akuma.whiplash.global.log.MethodLogSuppressor;
+import akuma.whiplash.global.log.NoMethodLog;
 
 @Slf4j
 @Aspect
@@ -31,22 +33,31 @@ public class MethodLoggingAspect {
     // Controller, Service 메서드 실행 전후 로깅
     @Around("within(@org.springframework.web.bind.annotation.RestController *) || within(@org.springframework.stereotype.Service *)")
     public Object logAroundMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
-        // Suppress 모드면 로깅하지 않고 바로 실행(로깅 X)
-        if (MethodLogSuppressor.isSuppressed()) {
-            return joinPoint.proceed();
+        boolean noLog = hasNoMethodLog(joinPoint);
+        boolean previousSuppressed = MethodLogSuppressor.isSuppressed();
+        if (noLog) {
+            MethodLogSuppressor.enable();
         }
 
-        
-        Instant methodStartTime = Instant.now();
+        if (previousSuppressed || noLog) {
+            try {
+                return joinPoint.proceed();
+            } finally {
+                if (noLog && !previousSuppressed) {
+                    MethodLogSuppressor.disable();
+                }
+            }
+        }
 
+        Instant methodStartTime = Instant.now();
         Object methodReturnValue = null;
         Throwable caughtException = null;
 
         try {
-            methodReturnValue = joinPoint.proceed(); // 실제 메서드 실행
+            methodReturnValue = joinPoint.proceed();
             return methodReturnValue;
         } catch (Throwable ex) {
-            caughtException = ex; // 예외 발생 시 저장
+            caughtException = ex;
             throw ex;
         } finally {
             long executionTimeMillis = Duration.between(methodStartTime, Instant.now()).toMillis();
@@ -64,46 +75,29 @@ public class MethodLoggingAspect {
                 clientIpAddress = LogUtils.clientIp(requestAttributes.getRequest());
             }
 
-            // 로그 데이터 Map 형태로 구성
             Map<String, Object> logDataMap = new LinkedHashMap<>();
-            logDataMap.put("type", LogConst.TYPE_METHOD); 
-            logDataMap.put("timestamp", LogUtils.nowIso()); 
-            logDataMap.put("clientIp", clientIpAddress); 
-            logDataMap.put("class", declaringClassName); 
-            logDataMap.put("method", methodName); 
+            logDataMap.put("type", LogConst.TYPE_METHOD);
+            logDataMap.put("timestamp", LogUtils.nowIso());
+            logDataMap.put("clientIp", clientIpAddress);
+            logDataMap.put("class", declaringClassName);
+            logDataMap.put("method", methodName);
             logDataMap.put("params", truncatedParams);
-            logDataMap.put("durationMs", executionTimeMillis); 
-            logDataMap.put("requestId", MDC.get(MDC_REQUEST_ID_KEY)); // 필터가 설정한 requestId를 함께 남겨 상관관계 분석 용이
+            logDataMap.put("durationMs", executionTimeMillis);
+            logDataMap.put("requestId", MDC.get(MDC_REQUEST_ID_KEY));
 
             if (caughtException != null) {
-                // 예외 발생시 예외 정보 로깅
-                logDataMap.put("exception", caughtException.getClass().getName()); 
-                logDataMap.put("exceptionMessage", caughtException.getMessage()); 
-                log.error(LogUtils.toJson(objectMapper, logDataMap)); 
+                logDataMap.put("exception", caughtException.getClass().getName());
+                logDataMap.put("exceptionMessage", caughtException.getMessage());
+                log.error(LogUtils.toJson(objectMapper, logDataMap));
             } else {
-                log.info(LogUtils.toJson(objectMapper, logDataMap)); 
+                log.info(LogUtils.toJson(objectMapper, logDataMap));
             }
         }
     }
 
-
-    /**
-     * @NoMethodLog 가 붙은 메서드/클래스의 실행 구간 동안
-     * 같은 스레드 체인에서 Method 로깅을 억제한다.
-     */
-    @Around("@within(akuma.whiplash.global.log.NoMethodLog) || @annotation(akuma.whiplash.global.log.NoMethodLog)")
-    public Object suppressByAnnotation(ProceedingJoinPoint pjp) throws Throwable {
-        boolean prev = MethodLogSuppressor.isSuppressed();
-        MethodLogSuppressor.enable();
-        try {
-            return pjp.proceed();
-        } finally {
-            // 중첩 억제에 대비: 이전 상태 복원
-            if (prev) {
-                MethodLogSuppressor.enable();
-            } else {
-                MethodLogSuppressor.disable();
-            }
-        }
+    private boolean hasNoMethodLog(ProceedingJoinPoint joinPoint) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        return AnnotationUtils.findAnnotation(method, NoMethodLog.class) != null
+            || AnnotationUtils.findAnnotation(joinPoint.getTarget().getClass(), NoMethodLog.class) != null;
     }
 }

--- a/src/main/java/akuma/whiplash/global/log/MethodLoggingAspect.java
+++ b/src/main/java/akuma/whiplash/global/log/MethodLoggingAspect.java
@@ -31,7 +31,12 @@ public class MethodLoggingAspect {
     private final ObjectMapper objectMapper;
 
     // Controller, Service 메서드 실행 전후 로깅
-    @Around("within(@org.springframework.web.bind.annotation.RestController *) || within(@org.springframework.stereotype.Service *)")
+    @Around(
+      "within(@org.springframework.web.bind.annotation.RestController *) || " +
+      "within(@org.springframework.stereotype.Service *) || " +
+      "@annotation(akuma.whiplash.global.log.NoMethodLog) || " +
+      "@within(akuma.whiplash.global.log.NoMethodLog)"
+    )
     public Object logAroundMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
         boolean noLog = hasNoMethodLog(joinPoint);
         boolean previousSuppressed = MethodLogSuppressor.isSuppressed();


### PR DESCRIPTION
## Summary
- honor `@NoMethodLog` annotation in MethodLoggingAspect and silence nested calls

## Testing
- `./gradlew test` *(fails: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f091516483269ec902c48d601518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음

- 버그 수정
  - 특정 어노테이션이 적용된 메서드/클래스의 호출이 간헐적으로 로그에 남던 문제를 해결했습니다.
  - 예외 발생 여부와 무관하게 로그 억제 상태가 일관되게 복원되도록 수정했습니다.

- 리팩터링
  - 로그 억제 판단 로직을 단일 경로로 일원화하고 중복 어드바이스를 제거했습니다.
  - 로깅 시작 시점을 정리해 불필요한 처리 경로를 감소시켰으며, 성능과 안정성을 개선했습니다.
  - 로그의 필드 구성과 JSON 출력 형식은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->