### PR TITLE
Fix sound type mapping to prevent null insertions

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/domain/constant/SoundType.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/constant/SoundType.java
@@ -16,9 +16,13 @@ public enum SoundType {
     private final String description;
 
     public static SoundType from(String description) {
+        if (description == null) {
+            return NONE;
+        }
+
         return Arrays.stream(values())
             .filter(s -> s.description.equals(description))
             .findFirst()
-            .orElse(null);
+            .orElse(NONE);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmEntity.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmEntity.java
@@ -20,6 +20,8 @@ import jakarta.persistence.Table;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -51,9 +53,10 @@ public class AlarmEntity extends BaseTimeEntity {
     @Column(name = "repeat_days", columnDefinition = "TEXT", nullable = false)
     private List<Weekday> repeatDays;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "sound_type", length = 20, nullable = false)
-    private SoundType soundType;
+    private SoundType soundType = SoundType.NONE;
 
     @Column(nullable = false)
     private Double latitude;

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/constant/SoundTypeTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/constant/SoundTypeTest.java
@@ -1,0 +1,57 @@
+package akuma.whiplash.domains.alarm.domain.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("SoundType - 소리 유형 변환")
+class SoundTypeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "소리 없음,NONE",
+        "알람 소리1,ONE",
+        "알람 소리2,TWO",
+        "알람 소리3,THREE",
+        "알람 소리4,FOUR"
+    })
+    @DisplayName("설명과 일치하는 소리 유형을 반환한다")
+    void returnsMatchingSoundType(String description, SoundType expected) {
+        // given
+
+        // when
+        SoundType soundType = SoundType.from(description);
+
+        // then
+        assertThat(soundType).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 설명을 입력하면 NONE으로 매핑된다")
+    void returnsNoneWhenDescriptionInvalid() {
+        // given
+        String description = "잘못된 소리";
+
+        // when
+        SoundType soundType = SoundType.from(description);
+
+        // then
+        assertThat(soundType).isEqualTo(SoundType.NONE);
+    }
+
+    @Test
+    @DisplayName("null을 입력하면 NONE으로 매핑된다")
+    void returnsNoneWhenDescriptionIsNull() {
+        // given
+        String description = null;
+
+        // when
+        SoundType soundType = SoundType.from(description);
+
+        // then
+        assertThat(soundType).isEqualTo(SoundType.NONE);
+    }
+}


### PR DESCRIPTION
## Summary
- default to `NONE` when alarm sound description is missing or null
- ensure AlarmEntity defaults sound type to `NONE` to avoid database insert errors
- add parameterized tests for `SoundType.from` mapping scenarios

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 bash gradlew test` *(fails: 24 tests completed, 11 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8065222c88326911a39bc4ab6ec89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 알람 소리 설명이 비어있거나 인식되지 않는 경우 자동으로 ‘소리 없음’으로 처리해 예외와 오동작을 예방했습니다.
  - 알람 생성/편집 시 소리 선택이 누락되어도 기본값으로 ‘소리 없음’이 적용되어 안정성이 향상되었습니다.

- 테스트
  - 소리 설명과 사운드 유형 매핑, 잘못된 값 및 null 입력에 대한 동작을 검증하는 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->