### PR TITLE
[#0] 🐛 Fix: avoid Sentry log for invalid tokens

### DIFF
--- a/src/main/java/akuma/whiplash/global/config/security/jwt/JwtUtils.java
+++ b/src/main/java/akuma/whiplash/global/config/security/jwt/JwtUtils.java
@@ -102,7 +102,7 @@ public class JwtUtils {
         response.setContentType(CONTENT_TYPE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
 
-        log.error("errorCode {}, errorMessage {}", error.getCustomCode(), error.getMessage());
+        log.warn("errorCode {}, errorMessage {}", error.getCustomCode(), error.getMessage());
 
         try {
             String json = new ObjectMapper().writeValueAsString(ApplicationResponse.onFailure(error.getCustomCode(), error.getMessage()));


### PR DESCRIPTION
## Summary
- avoid sending invalid or expired JWT token errors to Sentry by logging them as warnings

## Testing
- `./gradlew test` *(fails: Could not determine dependencies, Java 17 toolchain missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8281fa1388326a6becaff42893a4e