### PR TITLE
알람 등록시 시간이 자정인 경우에 파싱 오류를 해결한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmRegisterRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmRegisterRequest.java
@@ -1,5 +1,7 @@
 package akuma.whiplash.domains.alarm.application.dto.request;
 
+import akuma.whiplash.global.util.date.LocalTime24HourDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -34,6 +36,7 @@ public record AlarmRegisterRequest(
 
     @Schema(description = "알람 시간", example = "08:30")
     @NotNull(message = "알람 시간을 선택해주세요.")
+    @JsonDeserialize(using = LocalTime24HourDeserializer.class)
     LocalTime time,
 
     // TODO: 월~일 요일 검증 필요

--- a/src/main/java/akuma/whiplash/global/util/date/DateUtil.java
+++ b/src/main/java/akuma/whiplash/global/util/date/DateUtil.java
@@ -5,14 +5,19 @@ import static akuma.whiplash.domains.alarm.exception.AlarmErrorCode.REPEAT_DAYS_
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.response.code.CommonErrorCode;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class DateUtil {
 
     private DateUtil() {
@@ -52,6 +57,36 @@ public class DateUtil {
      */
     public static boolean isSameDay(LocalDateTime dateTime1, LocalDateTime dateTime2) {
         return dateTime1.toLocalDate().isEqual(dateTime2.toLocalDate());
+    }
+
+    /**
+     * 문자열을 {@link LocalTime}으로 변환합니다.
+     * 24시 형태("24:00", "24:30")는 다음 날 0시 형태("00:00", "00:30")로 변환하여 파싱합니다.
+     *
+     * @param timeString 시각 문자열
+     * @return 파싱된 {@link LocalTime}
+     * @throws DateTimeParseException 잘못된 형식의 문자열인 경우
+     */
+    public static LocalTime parseLocalTimeWith24HourSupport(String timeString) {
+        String normalized = "";
+
+        try {
+            if (timeString == null) {
+                log.warn("timeString must not be null");
+                throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+            }
+
+            normalized = timeString;
+            if (normalized.startsWith("24:")) {
+                normalized = "00" + normalized.substring(2);
+            }
+
+        } catch (DateTimeParseException e) {
+            log.warn(e.getMessage());
+            ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+        }
+
+        return LocalTime.parse(normalized);
     }
 
     public static String getKoreanDayOfWeek(LocalDate date) {

--- a/src/main/java/akuma/whiplash/global/util/date/LocalTime24HourDeserializer.java
+++ b/src/main/java/akuma/whiplash/global/util/date/LocalTime24HourDeserializer.java
@@ -1,0 +1,26 @@
+package akuma.whiplash.global.util.date;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import java.io.IOException;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+/**
+ * JsonDeserializer that delegates parsing to {@link DateUtil#parseLocalTimeWith24HourSupport(String)}
+ * to accept "24:xx" values and normalize them to "00:xx".
+ */
+public class LocalTime24HourDeserializer extends JsonDeserializer<LocalTime> {
+
+    @Override
+    public LocalTime deserialize(JsonParser p, DeserializationContext deserializationContext) throws IOException {
+        String value = p.getValueAsString();
+        try {
+            return DateUtil.parseLocalTimeWith24HourSupport(value);
+        } catch (DateTimeParseException e) {
+            throw JsonMappingException.from(p, "Invalid time format", e);
+        }
+    }
+}


### PR DESCRIPTION
## 📄 PR 요약
> 알람 등록시 시간이 자정인 경우에 파싱 오류를 해결한다.

## ✍🏻 PR 상세
1. DateTime Parser 적용

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #71 