### PR TITLE
인앱 결제로 알람 끄기 API를 구현한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmCheckinRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmCheckinRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 @Schema(description = "알람 도착 인증 요청 DTO")
 public record AlarmCheckinRequest(
@@ -28,11 +27,7 @@ public record AlarmCheckinRequest(
     @NotNull(message = "현재 사용자 위치의 경도를 입력해주세요.")
     @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
     @DecimalMax(value = "180.0", message = "경도는 180 이하이어야 합니다.")
-    Double longitude,
-
-    @Schema(description = "요청 시각", example = "2026-04-15T07:20:00")
-    @NotNull(message = "요청 시각을 입력해주세요.")
-    LocalDateTime requestedAt
+    Double longitude
 ) {
 
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmPaymentRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmPaymentRequest.java
@@ -1,0 +1,27 @@
+package akuma.whiplash.domains.alarm.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제로 알람 끄기 요청 DTO")
+public record AlarmPaymentRequest(
+
+    @Schema(description = "알람 발생 회차 ID", example = "501")
+    @NotNull(message = "알람 발생 회차 ID를 입력해주세요.")
+    Long occurrenceId,
+
+    @Schema(description = "요청 디바이스 UUID", example = "device-uuid")
+    @NotBlank(message = "디바이스 ID를 입력해주세요.")
+    String deviceId,
+
+    @Schema(description = "인앱 결제 영수증 ID", example = "pay_123")
+    @NotBlank(message = "결제 ID를 입력해주세요.")
+    String paymentId,
+
+    @Schema(description = "요청 시각 (ISO-8601)", example = "2026-04-15T07:25:00")
+    @NotNull(message = "요청 시각을 입력해주세요.")
+    LocalDateTime requestedAt
+) {
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmPaymentRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmPaymentRequest.java
@@ -3,7 +3,6 @@ package akuma.whiplash.domains.alarm.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 @Schema(description = "결제로 알람 끄기 요청 DTO")
 public record AlarmPaymentRequest(
@@ -18,10 +17,6 @@ public record AlarmPaymentRequest(
 
     @Schema(description = "인앱 결제 영수증 ID", example = "pay_123")
     @NotBlank(message = "결제 ID를 입력해주세요.")
-    String paymentId,
-
-    @Schema(description = "요청 시각 (ISO-8601)", example = "2026-04-15T07:25:00")
-    @NotNull(message = "요청 시각을 입력해주세요.")
-    LocalDateTime requestedAt
+    String paymentId
 ) {
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmPaymentResponse.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmPaymentResponse.java
@@ -1,0 +1,19 @@
+package akuma.whiplash.domains.alarm.application.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record AlarmPaymentResponse(
+    Long alarmId,
+    LocalDateTime deactivatedAt,
+    int alarmRevision,
+    NextOccurrenceInfo nextOccurrence
+) {
+    @Builder
+    public record NextOccurrenceInfo(
+        Long occurrenceId,
+        LocalDateTime scheduledAt
+    ) {
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
@@ -2,6 +2,7 @@ package akuma.whiplash.domains.alarm.application.mapper;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncItemDto;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
@@ -9,6 +10,7 @@ import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse
 import akuma.whiplash.domains.alarm.application.dto.response.NextOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPreviewDto;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivateType;
+import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
@@ -149,7 +151,7 @@ public class AlarmMapper {
             .requestDeviceId(deviceId)
             .requestedAt(requestedAt)
             .processedAt(processedAt)
-            .result("SUCCESS")
+            .result(DeactivationResult.SUCCESS)
             .failReason("")
             .build();
     }
@@ -165,6 +167,47 @@ public class AlarmMapper {
                 .occurrenceId(nextOccurrence.getId())
                 .scheduledAt(nextOccurrence.getScheduledAt())
                 .build())
+            .build();
+    }
+
+    public static AlarmPaymentResponse mapToAlarmPaymentResponse(
+        AlarmEntity alarm,
+        LocalDateTime deactivatedAt,
+        AlarmOccurrenceEntity nextOccurrence
+    ) {
+        return AlarmPaymentResponse.builder()
+            .alarmId(alarm.getId())
+            .deactivatedAt(deactivatedAt)
+            .alarmRevision(alarm.getRevision())
+            .nextOccurrence(nextOccurrence == null ? null : AlarmPaymentResponse.NextOccurrenceInfo.builder()
+                .occurrenceId(nextOccurrence.getId())
+                .scheduledAt(nextOccurrence.getScheduledAt())
+                .build())
+            .build();
+    }
+
+    public static AlarmDeactivationLogEntity mapToPaymentDeactivationLogEntity(
+        AlarmOccurrenceEntity occurrence,
+        MemberEntity member,
+        String paymentId,
+        String deviceId,
+        LocalDateTime requestedAt,
+        LocalDateTime processedAt,
+        DeactivationResult result,
+        String failReason
+    ) {
+        return AlarmDeactivationLogEntity.builder()
+            .alarmOccurrence(occurrence)
+            .member(member)
+            .paymentId(paymentId)
+            .deactivateType(DeactivateType.PAYMENT)
+            .requestLatitude(null)
+            .requestLongitude(null)
+            .requestDeviceId(deviceId)
+            .requestedAt(requestedAt)
+            .processedAt(processedAt)
+            .result(result)
+            .failReason(failReason)
             .build();
     }
 

--- a/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
@@ -1,8 +1,10 @@
 package akuma.whiplash.domains.alarm.application.usecase;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
@@ -33,6 +35,10 @@ public class AlarmUseCase {
 
     public AlarmCheckinResponse checkinAlarm(Long memberId, Long alarmId, AlarmCheckinRequest request) {
         return alarmCommandService.checkinAlarm(memberId, alarmId, request);
+    }
+
+    public AlarmPaymentResponse deactivateByPayment(Long memberId, Long alarmId, AlarmPaymentRequest request) {
+        return alarmCommandService.deactivateByPayment(memberId, alarmId, request);
     }
 
     public void ringAlarm(Long memberId, Long alarmId) {

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/constant/DeactivateType.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/constant/DeactivateType.java
@@ -1,5 +1,5 @@
 package akuma.whiplash.domains.alarm.domain.constant;
 
 public enum DeactivateType {
-    CHECKIN, OFF, NONE
+    CHECKIN, PAYMENT, OFF, NONE
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/constant/DeactivationResult.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/constant/DeactivationResult.java
@@ -1,0 +1,6 @@
+package akuma.whiplash.domains.alarm.domain.constant;
+
+public enum DeactivationResult {
+    SUCCESS,
+    FAIL
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandService.java
@@ -1,8 +1,10 @@
 package akuma.whiplash.domains.alarm.domain.service;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import java.util.Set;
@@ -13,6 +15,7 @@ public interface AlarmCommandService {
     CreateAlarmOccurrenceResponse createAlarmOccurrence(Long memberId, Long alarmId);
     void removeAlarm(Long memberId, Long alarmId, String reason);
     AlarmCheckinResponse checkinAlarm(Long memberId, Long alarmId, AlarmCheckinRequest request);
+    AlarmPaymentResponse deactivateByPayment(Long memberId, Long alarmId, AlarmPaymentRequest request);
     void ringAlarm(Long memberId, Long alarmId);
     void markReminderSent(Set<Long> occurrenceIds);
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
@@ -4,27 +4,42 @@ import static akuma.whiplash.domains.alarm.exception.AlarmErrorCode.*;
 
 import akuma.whiplash.domains.alarm.application.event.AlarmCheckinCompletedEvent;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import akuma.whiplash.domains.alarm.application.mapper.AlarmMapper;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
+import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmRingingLogEntity;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmDeactivationLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOffLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRingingLogRepository;
 import akuma.whiplash.domains.auth.exception.AuthErrorCode;
+import akuma.whiplash.domains.device.exception.DeviceErrorCode;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.member.persistence.entity.MemberDeviceEntity;
+import akuma.whiplash.domains.member.persistence.repository.MemberDeviceRepository;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
+import akuma.whiplash.domains.payment.application.mapper.PaymentMapper;
+import akuma.whiplash.domains.payment.domain.constant.PaymentStatus;
+import akuma.whiplash.domains.payment.domain.constant.PaymentType;
+import akuma.whiplash.domains.payment.exception.PaymentErrorCode;
+import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.response.code.CommonErrorCode;
 import akuma.whiplash.global.service.ArchiveService;
 import akuma.whiplash.global.util.date.DateUtil;
+import akuma.whiplash.global.util.date.TimeProvider;
+import akuma.whiplash.infrastructure.payment.PaymentVerificationPort;
 import akuma.whiplash.infrastructure.redis.RingingAlarmRedisRepository;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.SheetsScopes;
@@ -40,6 +55,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -60,10 +76,15 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     private final AlarmOccurrenceRepository alarmOccurrenceRepository;
     private final AlarmOffLogRepository alarmOffLogRepository;
     private final AlarmRingingLogRepository alarmRingingLogRepository;
+    private final AlarmDeactivationLogRepository alarmDeactivationLogRepository;
     private final MemberRepository memberRepository;
+    private final MemberDeviceRepository memberDeviceRepository;
+    private final PaymentRepository paymentRepository;
+    private final List<PaymentVerificationPort> paymentVerificationPorts;
     private final ArchiveService archiveService;
     private final RingingAlarmRedisRepository ringingAlarmRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final TimeProvider timeProvider;
 
     @Value("${oauth.google.sheet.id}")
     private String spreadsheetsId;
@@ -95,7 +116,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             .collect(Collectors.toSet());
         
         // 현재 시각 기준으로 가장 가까운 발생일 계산 (오늘 포함 여부는 getNextOccurrenceDate 내부 로직 따름)
-        LocalDate nextDate = DateUtil.getNextOccurrenceDate(repeatDays, LocalDateTime.now(), alarm.getTime());
+        LocalDate nextDate = DateUtil.getNextOccurrenceDate(repeatDays, timeProvider.now(), alarm.getTime());
         LocalDateTime nextScheduledTime = LocalDateTime.of(nextDate, alarm.getTime());
 
         // 3. 첫 알람 발생 내역 생성 및 저장
@@ -115,7 +136,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         validAlarmOwner(memberId, alarmEntity.getMember().getId());
 
         // 각 알람이 울릴 때 알람 발생 내역은 1개만 허용(반복 울림은 alarm_ringing_log로 관리), 오늘 날짜 기준 알람 발생 내역이 이미 존재하면 예외 발생
-        boolean alreadyExists = alarmOccurrenceRepository.existsByAlarmIdAndDate(alarmId, LocalDate.now());
+        boolean alreadyExists = alarmOccurrenceRepository.existsByAlarmIdAndDate(alarmId, timeProvider.today());
         if (alreadyExists) {
             throw ApplicationException.from(ALREADY_OCCURRED_EXISTS);
         }
@@ -189,7 +210,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 5. 체크인 완료 시각을 기록하고 회차 상태를 CHECKIN으로 전환한다.
-        LocalDateTime processedAt = LocalDateTime.now();
+        LocalDateTime processedAt = timeProvider.now();
         occurrence.checkin(processedAt);
 
         // 6. 더 이상 울리는 알람이 아니므로 캐시에서 제거하고 알람 revision을 증가시킨다.
@@ -220,6 +241,128 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     }
 
     @Override
+    // 결제 검증 실패도 payment(FAILED)와 비활성화 실패 로그를 남겨야 하므로 ApplicationException으로 롤백하지 않는다.
+    @Transactional(noRollbackFor = ApplicationException.class)
+    public AlarmPaymentResponse deactivateByPayment(Long memberId, Long alarmId, AlarmPaymentRequest request) {
+        // 1. 알람을 조회하고 요청자가 알람 소유자인지 검증한다.
+        AlarmEntity alarm = findAlarmById(alarmId);
+        MemberEntity member = alarm.getMember();
+        validAlarmOwner(memberId, member.getId());
+
+        // 2. 요청한 알람 회차가 해당 알람에 속하는지 확인한다.
+        AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository
+            .findByIdAndAlarmId(request.occurrenceId(), alarmId)
+            .orElseThrow(() -> ApplicationException.from(ALARM_OCCURRENCE_NOT_FOUND));
+
+        // 3. 이미 처리된 회차는 중복 비활성화하지 않는다.
+        if (occurrence.getStatus() != OccurrenceStatus.SCHEDULED
+            && occurrence.getStatus() != OccurrenceStatus.RINGING) {
+            throw ApplicationException.from(ALREADY_DEACTIVATED);
+        }
+
+        // 4. 결제 비활성화는 알람 예정 시각 3시간 전부터만 허용한다.
+        LocalDateTime paymentAvailableAt = occurrence.getScheduledAt().minusHours(3);
+        if (request.requestedAt().isBefore(paymentAvailableAt)) {
+            throw ApplicationException.from(CHECKIN_NOT_YET_AVAILABLE);
+        }
+
+        // 5. 같은 플랫폼 결제 ID가 이미 처리됐다면 재사용을 막는다.
+        if (paymentRepository.existsByPaymentId(request.paymentId())) {
+            throw ApplicationException.from(PaymentErrorCode.DUPLICATE_PAYMENT);
+        }
+
+        // 6. 요청 디바이스의 플랫폼에 맞는 결제 검증 클라이언트로 영수증을 검증한다.
+        PaymentVerificationPort paymentClient = resolvePaymentClient(memberId, request.deviceId());
+        LocalDateTime processedAt = timeProvider.now();
+        boolean validPayment;
+        String verificationFailReason = "";
+        try {
+            validPayment = paymentClient.verify(request.paymentId());
+            if (!validPayment) {
+                verificationFailReason = buildPaymentVerificationFailReason(
+                    paymentClient,
+                    request.paymentId(),
+                    alarmId,
+                    occurrence.getId(),
+                    "verification returned false"
+                );
+            }
+        } catch (Exception e) {
+            validPayment = false;
+            verificationFailReason = buildPaymentVerificationFailReason(
+                paymentClient,
+                request.paymentId(),
+                alarmId,
+                occurrence.getId(),
+                e.getClass().getSimpleName() + ": " + e.getMessage()
+            );
+        }
+
+        // 7. 검증 실패도 감사 추적을 위해 실패 결제와 상세 실패 로그를 저장한 뒤 400으로 응답한다.
+        if (!validPayment) {
+            paymentRepository.save(PaymentMapper.mapToPaymentEntity(
+                member,
+                alarm,
+                request.paymentId(),
+                PaymentType.STOP_ALARM,
+                PaymentStatus.FAILED
+            ));
+
+            alarmDeactivationLogRepository.save(AlarmMapper.mapToPaymentDeactivationLogEntity(
+                occurrence,
+                member,
+                request.paymentId(),
+                request.deviceId(),
+                request.requestedAt(),
+                processedAt,
+                DeactivationResult.FAIL,
+                verificationFailReason
+            ));
+            throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+        }
+
+        // 8. 검증 성공 시 결제를 성공으로 기록하고 알람 회차를 PAYMENT 상태로 비활성화한다.
+        paymentRepository.save(PaymentMapper.mapToPaymentEntity(
+            member,
+            alarm,
+            request.paymentId(),
+            PaymentType.STOP_ALARM,
+            PaymentStatus.SUCCESS
+        ));
+        occurrence.deactivateByPayment(processedAt);
+        alarm.incrementRevision();
+        ringingAlarmRedisRepository.remove(alarmId, memberId);
+
+        // 9. 클라이언트 동기화와 운영 추적을 위해 성공 로그를 남긴다.
+        alarmDeactivationLogRepository.save(AlarmMapper.mapToPaymentDeactivationLogEntity(
+            occurrence,
+            member,
+            request.paymentId(),
+            request.deviceId(),
+            request.requestedAt(),
+            processedAt,
+            DeactivationResult.SUCCESS,
+            ""
+        ));
+
+        // 10. consume은 외부 플랫폼 후처리이므로 실패해도 알람 비활성화 트랜잭션은 유지한다.
+        try {
+            paymentClient.consume(request.paymentId());
+        } catch (Exception e) {
+            log.warn("Failed to consume payment. paymentId={}", request.paymentId(), e);
+        }
+
+        // 11. 변경된 revision과 다음 예약 회차를 함께 내려 클라이언트가 로컬 알람을 재동기화하게 한다.
+        AlarmOccurrenceEntity nextOccurrence = alarmOccurrenceRepository
+            .findNextScheduledByAlarmIds(List.of(alarmId), OccurrenceStatus.SCHEDULED, processedAt)
+            .stream()
+            .findFirst()
+            .orElse(null);
+
+        return AlarmMapper.mapToAlarmPaymentResponse(alarm, processedAt, nextOccurrence);
+    }
+
+    @Override
     public void ringAlarm(Long memberId, Long alarmId) {
         AlarmEntity alarm = findAlarmById(alarmId);
         validAlarmOwner(memberId, alarm.getMember().getId());
@@ -233,7 +376,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             .orElseThrow(() -> ApplicationException.from(ALARM_OCCURRENCE_NOT_FOUND));
 
         // 아직 알람이 울릴 시간이 아니라면 예외 발생
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = timeProvider.now();
         LocalDateTime scheduledDateTime = LocalDateTime.of(occurrence.getOccurrenceDate(), occurrence.getOccurrenceTime());
         if (now.isBefore(scheduledDateTime)) {
             throw ApplicationException.from(NOT_ALARM_TIME);
@@ -308,7 +451,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
 
             // 2. 기록할 값 구성
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            String formattedDateTime = LocalDateTime.now().format(formatter);
+            String formattedDateTime = timeProvider.now().format(formatter);
 
             ValueRange body = new ValueRange().setValues(
                 List.of(List.of(alarmPurpose, reason, formattedDateTime))
@@ -333,6 +476,33 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     private AlarmEntity findAlarmById(Long alarmId) {
         return alarmRepository.findById(alarmId)
             .orElseThrow(() -> ApplicationException.from(ALARM_NOT_FOUND));
+    }
+
+    private PaymentVerificationPort resolvePaymentClient(Long memberId, String deviceId) {
+        MemberDeviceEntity device = memberDeviceRepository.findByMember_IdAndDeviceId(memberId, deviceId)
+            .orElseThrow(() -> ApplicationException.from(DeviceErrorCode.DEVICE_NOT_FOUND));
+
+        String platform = device.getPlatform().toUpperCase(Locale.ROOT);
+
+        return paymentVerificationPorts.stream()
+            .filter(port -> port.supportedPlatform().equals(platform))
+            .findFirst()
+            .orElseThrow(() -> ApplicationException.from(CommonErrorCode.BAD_REQUEST));
+    }
+
+    private String buildPaymentVerificationFailReason(
+        PaymentVerificationPort paymentClient,
+        String paymentId,
+        Long alarmId,
+        Long occurrenceId,
+        String reason
+    ) {
+        return "PAYMENT_VERIFICATION_FAILED"
+            + " platform=" + paymentClient.supportedPlatform()
+            + ", paymentId=" + paymentId
+            + ", alarmId=" + alarmId
+            + ", occurrenceId=" + occurrenceId
+            + ", reason=" + reason;
     }
 
     private static void validAlarmOwner(Long reqMemberId, Long alarmMemberId) {

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
@@ -194,9 +194,8 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 3. 위치 인증은 예정 시각 3시간 전부터만 허용한다.
-        LocalDateTime requestedAt = request.requestedAt();
         LocalDateTime checkinAvailableAt = occurrence.getScheduledAt().minusHours(3);
-        if (requestedAt.isBefore(checkinAvailableAt)) {
+        if (timeProvider.now().isBefore(checkinAvailableAt)) {
             throw ApplicationException.from(CHECKIN_NOT_YET_AVAILABLE);
         }
 
@@ -262,8 +261,8 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
 
         // 4. 결제 비활성화는 알람 예정 시각 3시간 전부터만 허용한다.
         LocalDateTime paymentAvailableAt = occurrence.getScheduledAt().minusHours(3);
-        if (request.requestedAt().isBefore(paymentAvailableAt)) {
-            throw ApplicationException.from(CHECKIN_NOT_YET_AVAILABLE);
+        if (timeProvider.now().isBefore(paymentAvailableAt)) {
+            throw ApplicationException.from(PaymentErrorCode.PAYMENT_NOT_YET_AVAILABLE);
         }
 
         // 5. 같은 플랫폼 결제 ID가 이미 처리됐다면 재사용을 막는다.
@@ -318,7 +317,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
                 DeactivationResult.FAIL,
                 verificationFailReason
             ));
-            throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+            throw ApplicationException.from(PaymentErrorCode.PAYMENT_VERIFICATION_FAILED);
         }
 
         // 8. 검증 성공 시 결제를 성공으로 기록하고 알람 회차를 PAYMENT 상태로 비활성화한다.

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
@@ -194,8 +194,9 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 3. 위치 인증은 예정 시각 3시간 전부터만 허용한다.
+        LocalDateTime processedAt = timeProvider.now();
         LocalDateTime checkinAvailableAt = occurrence.getScheduledAt().minusHours(3);
-        if (timeProvider.now().isBefore(checkinAvailableAt)) {
+        if (processedAt.isBefore(checkinAvailableAt)) {
             throw ApplicationException.from(CHECKIN_NOT_YET_AVAILABLE);
         }
 
@@ -209,7 +210,6 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 5. 체크인 완료 시각을 기록하고 회차 상태를 CHECKIN으로 전환한다.
-        LocalDateTime processedAt = timeProvider.now();
         occurrence.checkin(processedAt);
 
         // 6. 더 이상 울리는 알람이 아니므로 캐시에서 제거하고 알람 revision을 증가시킨다.
@@ -231,7 +231,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             request.deviceId(),
             request.latitude(),
             request.longitude(),
-            request.requestedAt(),
+            processedAt,
             processedAt
         ));
 
@@ -260,8 +260,9 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 4. 결제 비활성화는 알람 예정 시각 3시간 전부터만 허용한다.
+        LocalDateTime processedAt = timeProvider.now();
         LocalDateTime paymentAvailableAt = occurrence.getScheduledAt().minusHours(3);
-        if (timeProvider.now().isBefore(paymentAvailableAt)) {
+        if (processedAt.isBefore(paymentAvailableAt)) {
             throw ApplicationException.from(PaymentErrorCode.PAYMENT_NOT_YET_AVAILABLE);
         }
 
@@ -272,7 +273,6 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
 
         // 6. 요청 디바이스의 플랫폼에 맞는 결제 검증 클라이언트로 영수증을 검증한다.
         PaymentVerificationPort paymentClient = resolvePaymentClient(memberId, request.deviceId());
-        LocalDateTime processedAt = timeProvider.now();
         boolean validPayment;
         String verificationFailReason = "";
         try {
@@ -312,7 +312,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
                 member,
                 request.paymentId(),
                 request.deviceId(),
-                request.requestedAt(),
+                processedAt,
                 processedAt,
                 DeactivationResult.FAIL,
                 verificationFailReason
@@ -338,7 +338,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             member,
             request.paymentId(),
             request.deviceId(),
-            request.requestedAt(),
+            processedAt,
             processedAt,
             DeactivationResult.SUCCESS,
             ""

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmDeactivationLogEntity.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmDeactivationLogEntity.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.domains.alarm.persistence.entity;
 
 import akuma.whiplash.domains.alarm.domain.constant.DeactivateType;
+import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.global.entity.BaseTimeEntity;
 import jakarta.persistence.Access;
@@ -66,9 +67,10 @@ public class AlarmDeactivationLogEntity extends BaseTimeEntity {
     @Column(name = "processed_at", nullable = false)
     private LocalDateTime processedAt;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "result", length = 20, nullable = false)
-    private String result;
+    private DeactivationResult result;
 
-    @Column(name = "fail_reason", length = 100, nullable = false)
+    @Column(name = "fail_reason", length = 500, nullable = false)
     private String failReason;
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmOccurrenceEntity.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmOccurrenceEntity.java
@@ -85,6 +85,12 @@ public class AlarmOccurrenceEntity extends BaseTimeEntity {
         this.alarmRinging = false;
     }
 
+    public void deactivateByPayment(LocalDateTime now) {
+        this.status = OccurrenceStatus.PAYMENT;
+        this.deactivatedAt = now;
+        this.alarmRinging = false;
+    }
+
     public int ring() {
         this.status = OccurrenceStatus.RINGING;
         this.alarmRinging = true;

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
@@ -10,7 +10,9 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,6 +47,7 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     WHERE ao.id = :occurrenceId
       AND ao.alarm.id = :alarmId
     """)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<AlarmOccurrenceEntity> findByIdAndAlarmId(
         @Param("occurrenceId") Long occurrenceId,
         @Param("alarmId") Long alarmId

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -2,12 +2,17 @@ package akuma.whiplash.domains.alarm.presentation;
 
 import static akuma.whiplash.domains.alarm.exception.AlarmErrorCode.*;
 import static akuma.whiplash.domains.auth.exception.AuthErrorCode.*;
+import static akuma.whiplash.domains.device.exception.DeviceErrorCode.*;
 import static akuma.whiplash.domains.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static akuma.whiplash.domains.payment.exception.PaymentErrorCode.*;
+import static akuma.whiplash.global.response.code.CommonErrorCode.*;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRemoveRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.GetAlarmsResponse;
@@ -62,6 +67,20 @@ public class AlarmController {
         return ApplicationResponse.onSuccess();
     }
 
+    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
+    @Operation(summary = "알람 목록 조회", description = "사용자가 등록한 알람 목록을 조회합니다.")
+    @GetMapping
+    public ApplicationResponse<GetAlarmsResponse> getAlarms(@AuthenticationPrincipal MemberContext memberContext) {
+        return ApplicationResponse.onSuccess(alarmUseCase.getAlarms(memberContext.memberId()));
+    }
+
+    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
+    @Operation(summary = "알람 전체 동기화 조회", description = "서버 기준 알람 상태를 조회하여 로컬 알람과 동기화합니다.")
+    @GetMapping("/sync")
+    public ApplicationResponse<AlarmSyncResponse> syncAlarms(@AuthenticationPrincipal MemberContext memberContext) {
+        return ApplicationResponse.onSuccess(alarmUseCase.getSyncAlarms(memberContext.memberId()));
+    }
+
     @CustomErrorCodes(
         alarmErrorCodes = {
             ALARM_NOT_FOUND,
@@ -82,18 +101,28 @@ public class AlarmController {
         return ApplicationResponse.onSuccess(alarmUseCase.checkinAlarm(memberContext.memberId(), alarmId, request));
     }
 
-    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
-    @Operation(summary = "알람 목록 조회", description = "사용자가 등록한 알람 목록을 조회합니다.")
-    @GetMapping
-    public ApplicationResponse<GetAlarmsResponse> getAlarms(@AuthenticationPrincipal MemberContext memberContext) {
-        return ApplicationResponse.onSuccess(alarmUseCase.getAlarms(memberContext.memberId()));
-    }
-
-    @CustomErrorCodes(memberErrorCodes = {MEMBER_NOT_FOUND})
-    @Operation(summary = "알람 전체 동기화 조회", description = "서버 기준 알람 상태를 조회하여 로컬 알람과 동기화합니다.")
-    @GetMapping("/sync")
-    public ApplicationResponse<AlarmSyncResponse> syncAlarms(@AuthenticationPrincipal MemberContext memberContext) {
-        return ApplicationResponse.onSuccess(alarmUseCase.getSyncAlarms(memberContext.memberId()));
+    @CustomErrorCodes(
+        alarmErrorCodes = {
+            ALARM_NOT_FOUND,
+            ALARM_OCCURRENCE_NOT_FOUND,
+            ALREADY_DEACTIVATED,
+            CHECKIN_NOT_YET_AVAILABLE
+        },
+        paymentErrorCodes = {DUPLICATE_PAYMENT},
+        commonErrorCodes = {BAD_REQUEST},
+        deviceErrorCodes = {DEVICE_NOT_FOUND},
+        authErrorCodes = {PERMISSION_DENIED}
+    )
+    @Operation(summary = "결제로 알람 끄기", description = "인앱 결제를 통해 알람 회차를 비활성화합니다.")
+    @PostMapping("/{alarmId}/payment")
+    public ApplicationResponse<AlarmPaymentResponse> deactivateByPayment(
+        @AuthenticationPrincipal MemberContext memberContext,
+        @PathVariable Long alarmId,
+        @RequestBody @Valid AlarmPaymentRequest request
+    ) {
+        return ApplicationResponse.onSuccess(
+            alarmUseCase.deactivateByPayment(memberContext.memberId(), alarmId, request)
+        );
     }
 
     @CustomErrorCodes(

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -5,7 +5,6 @@ import static akuma.whiplash.domains.auth.exception.AuthErrorCode.*;
 import static akuma.whiplash.domains.device.exception.DeviceErrorCode.*;
 import static akuma.whiplash.domains.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static akuma.whiplash.domains.payment.exception.PaymentErrorCode.*;
-import static akuma.whiplash.global.response.code.CommonErrorCode.*;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
@@ -105,11 +104,13 @@ public class AlarmController {
         alarmErrorCodes = {
             ALARM_NOT_FOUND,
             ALARM_OCCURRENCE_NOT_FOUND,
-            ALREADY_DEACTIVATED,
-            CHECKIN_NOT_YET_AVAILABLE
+            ALREADY_DEACTIVATED
         },
-        paymentErrorCodes = {DUPLICATE_PAYMENT},
-        commonErrorCodes = {BAD_REQUEST},
+        paymentErrorCodes = {
+            DUPLICATE_PAYMENT,
+            PAYMENT_NOT_YET_AVAILABLE,
+            PAYMENT_VERIFICATION_FAILED
+        },
         deviceErrorCodes = {DEVICE_NOT_FOUND},
         authErrorCodes = {PERMISSION_DENIED}
     )

--- a/src/main/java/akuma/whiplash/domains/payment/application/mapper/PaymentMapper.java
+++ b/src/main/java/akuma/whiplash/domains/payment/application/mapper/PaymentMapper.java
@@ -24,7 +24,7 @@ public class PaymentMapper {
             .alarm(alarm)
             .paymentId(paymentId)
             .paymentType(paymentType)
-            .amount(0)
+            .amount(0) // TODO: 실제 스토어 검증 연동 후 productId/영수증 기준 결제 금액을 저장한다.
             .status(status)
             .build();
     }

--- a/src/main/java/akuma/whiplash/domains/payment/application/mapper/PaymentMapper.java
+++ b/src/main/java/akuma/whiplash/domains/payment/application/mapper/PaymentMapper.java
@@ -1,0 +1,31 @@
+package akuma.whiplash.domains.payment.application.mapper;
+
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.payment.domain.constant.PaymentStatus;
+import akuma.whiplash.domains.payment.domain.constant.PaymentType;
+import akuma.whiplash.domains.payment.persistence.entity.PaymentEntity;
+
+public class PaymentMapper {
+
+    private PaymentMapper() {
+        throw new IllegalArgumentException();
+    }
+
+    public static PaymentEntity mapToPaymentEntity(
+        MemberEntity member,
+        AlarmEntity alarm,
+        String paymentId,
+        PaymentType paymentType,
+        PaymentStatus status
+    ) {
+        return PaymentEntity.builder()
+            .member(member)
+            .alarm(alarm)
+            .paymentId(paymentId)
+            .paymentType(paymentType)
+            .amount(0)
+            .status(status)
+            .build();
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/payment/domain/constant/PaymentStatus.java
+++ b/src/main/java/akuma/whiplash/domains/payment/domain/constant/PaymentStatus.java
@@ -1,0 +1,7 @@
+package akuma.whiplash.domains.payment.domain.constant;
+
+public enum PaymentStatus {
+    SUCCESS,
+    FAILED,
+    REFUNDED
+}

--- a/src/main/java/akuma/whiplash/domains/payment/domain/constant/PaymentType.java
+++ b/src/main/java/akuma/whiplash/domains/payment/domain/constant/PaymentType.java
@@ -1,0 +1,6 @@
+package akuma.whiplash.domains.payment.domain.constant;
+
+public enum PaymentType {
+    STOP_ALARM,
+    DELETE_ALARM
+}

--- a/src/main/java/akuma/whiplash/domains/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/akuma/whiplash/domains/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,18 @@
+package akuma.whiplash.domains.payment.exception;
+
+import akuma.whiplash.global.response.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements BaseErrorCode {
+
+    DUPLICATE_PAYMENT(HttpStatus.CONFLICT, "PAYMENT_901", "이미 처리된 결제입니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_401", "존재하지 않는 결제입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/akuma/whiplash/domains/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/akuma/whiplash/domains/payment/exception/PaymentErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PaymentErrorCode implements BaseErrorCode {
 
+    PAYMENT_NOT_YET_AVAILABLE(HttpStatus.BAD_REQUEST, "PAYMENT_001", "아직 결제로 알람을 끌 수 있는 시간이 아닙니다."),
+    PAYMENT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_002", "결제 검증에 실패했습니다."),
     DUPLICATE_PAYMENT(HttpStatus.CONFLICT, "PAYMENT_901", "이미 처리된 결제입니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_401", "존재하지 않는 결제입니다.");
 

--- a/src/main/java/akuma/whiplash/domains/payment/persistence/entity/PaymentEntity.java
+++ b/src/main/java/akuma/whiplash/domains/payment/persistence/entity/PaymentEntity.java
@@ -1,0 +1,62 @@
+package akuma.whiplash.domains.payment.persistence.entity;
+
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.payment.domain.constant.PaymentStatus;
+import akuma.whiplash.domains.payment.domain.constant.PaymentType;
+import akuma.whiplash.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@SuperBuilder
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment")
+public class PaymentEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_id", nullable = false)
+    private AlarmEntity alarm;
+
+    @Column(name = "payment_id", length = 100, nullable = false, unique = true)
+    private String paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", length = 20, nullable = false)
+    private PaymentType paymentType;
+
+    @Column(name = "amount", nullable = false)
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private PaymentStatus status;
+
+    public void markRefunded() {
+        this.status = PaymentStatus.REFUNDED;
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/payment/persistence/repository/PaymentRepository.java
+++ b/src/main/java/akuma/whiplash/domains/payment/persistence/repository/PaymentRepository.java
@@ -1,0 +1,12 @@
+package akuma.whiplash.domains.payment.persistence.repository;
+
+import akuma.whiplash.domains.payment.persistence.entity.PaymentEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+
+    boolean existsByPaymentId(String paymentId);
+
+    Optional<PaymentEntity> findByPaymentId(String paymentId);
+}

--- a/src/main/java/akuma/whiplash/global/annotation/swagger/CustomErrorCodes.java
+++ b/src/main/java/akuma/whiplash/global/annotation/swagger/CustomErrorCodes.java
@@ -4,6 +4,7 @@ import akuma.whiplash.domains.alarm.exception.AlarmErrorCode;
 import akuma.whiplash.domains.auth.exception.AuthErrorCode;
 import akuma.whiplash.domains.device.exception.DeviceErrorCode;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
+import akuma.whiplash.domains.payment.exception.PaymentErrorCode;
 import akuma.whiplash.global.response.code.CommonErrorCode;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -19,4 +20,5 @@ public @interface CustomErrorCodes {
     MemberErrorCode[] memberErrorCodes() default {};
     AlarmErrorCode[] alarmErrorCodes() default {};
     DeviceErrorCode[] deviceErrorCodes() default {};
+    PaymentErrorCode[] paymentErrorCodes() default {};
 }

--- a/src/main/java/akuma/whiplash/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/akuma/whiplash/global/config/swagger/SwaggerConfig.java
@@ -4,6 +4,7 @@ import akuma.whiplash.domains.alarm.exception.AlarmErrorCode;
 import akuma.whiplash.domains.auth.exception.AuthErrorCode;
 import akuma.whiplash.domains.device.exception.DeviceErrorCode;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
+import akuma.whiplash.domains.payment.exception.PaymentErrorCode;
 import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
 import akuma.whiplash.global.response.code.BaseErrorCode;
@@ -94,7 +95,8 @@ public class SwaggerConfig {
                     customErrorCodes.alarmErrorCodes(),
                     customErrorCodes.authErrorCodes(),
                     customErrorCodes.memberErrorCodes(),
-                    customErrorCodes.deviceErrorCodes()
+                    customErrorCodes.deviceErrorCodes(),
+                    customErrorCodes.paymentErrorCodes()
                 );
             }
 
@@ -108,7 +110,8 @@ public class SwaggerConfig {
             AlarmErrorCode[] alarmErrorCodes,
             AuthErrorCode[] authErrorCodes,
             MemberErrorCode[] memberErrorCodes,
-            DeviceErrorCode[] deviceErrorCodes
+            DeviceErrorCode[] deviceErrorCodes,
+            PaymentErrorCode[] paymentErrorCodes
     ) {
         ApiResponses responses = operation.getResponses();
 
@@ -134,6 +137,11 @@ public class SwaggerConfig {
             }
 
             for (DeviceErrorCode errorCode : deviceErrorCodes) {
+                SwaggerExampleHolder SwaggerExampleHolder = getSwaggerExampleHolder(errorCode);
+                addExamplesToResponses(responses, SwaggerExampleHolder);
+            }
+
+            for (PaymentErrorCode errorCode : paymentErrorCodes) {
                 SwaggerExampleHolder SwaggerExampleHolder = getSwaggerExampleHolder(errorCode);
                 addExamplesToResponses(responses, SwaggerExampleHolder);
             }

--- a/src/main/java/akuma/whiplash/global/util/date/TimeProvider.java
+++ b/src/main/java/akuma/whiplash/global/util/date/TimeProvider.java
@@ -1,0 +1,30 @@
+package akuma.whiplash.global.util.date;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeProvider {
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+    private final Clock clock;
+
+    public TimeProvider() {
+        this(Clock.system(DEFAULT_ZONE));
+    }
+
+    public TimeProvider(Clock clock) {
+        this.clock = clock.withZone(DEFAULT_ZONE);
+    }
+
+    public LocalDateTime now() {
+        return LocalDateTime.now(clock);
+    }
+
+    public LocalDate today() {
+        return LocalDate.now(clock);
+    }
+}

--- a/src/main/java/akuma/whiplash/infrastructure/payment/AppStorePaymentClient.java
+++ b/src/main/java/akuma/whiplash/infrastructure/payment/AppStorePaymentClient.java
@@ -1,0 +1,23 @@
+package akuma.whiplash.infrastructure.payment;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppStorePaymentClient implements PaymentVerificationPort {
+
+    @Override
+    public boolean verify(String transactionId) {
+        // TODO: App Store inApps/v1/transactions 연동 전까지 local/dev 검증용 스텁으로 사용한다.
+        return transactionId != null && !transactionId.isBlank();
+    }
+
+    @Override
+    public void consume(String transactionId) {
+        // App Store는 서버 consume 단계가 없고 클라이언트 finishTransaction 책임으로 둔다.
+    }
+
+    @Override
+    public String supportedPlatform() {
+        return "IOS";
+    }
+}

--- a/src/main/java/akuma/whiplash/infrastructure/payment/AppStorePaymentClient.java
+++ b/src/main/java/akuma/whiplash/infrastructure/payment/AppStorePaymentClient.java
@@ -1,13 +1,15 @@
 package akuma.whiplash.infrastructure.payment;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile({"local", "dev", "qa"})
 public class AppStorePaymentClient implements PaymentVerificationPort {
 
     @Override
     public boolean verify(String transactionId) {
-        // TODO: App Store inApps/v1/transactions 연동 전까지 local/dev 검증용 스텁으로 사용한다.
+        // TODO: prod에서는 App Store inApps/v1/transactions 기반 실제 검증 구현체를 등록한다.
         return transactionId != null && !transactionId.isBlank();
     }
 

--- a/src/main/java/akuma/whiplash/infrastructure/payment/GooglePlayPaymentClient.java
+++ b/src/main/java/akuma/whiplash/infrastructure/payment/GooglePlayPaymentClient.java
@@ -1,13 +1,15 @@
 package akuma.whiplash.infrastructure.payment;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile({"local", "dev", "qa"})
 public class GooglePlayPaymentClient implements PaymentVerificationPort {
 
     @Override
     public boolean verify(String purchaseToken) {
-        // TODO: Google Play purchases.products.get 연동 전까지 local/dev 검증용 스텁으로 사용한다.
+        // TODO: prod에서는 Google Play purchases.products.get 기반 실제 검증 구현체를 등록한다.
         return purchaseToken != null && !purchaseToken.isBlank();
     }
 

--- a/src/main/java/akuma/whiplash/infrastructure/payment/GooglePlayPaymentClient.java
+++ b/src/main/java/akuma/whiplash/infrastructure/payment/GooglePlayPaymentClient.java
@@ -1,0 +1,23 @@
+package akuma.whiplash.infrastructure.payment;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GooglePlayPaymentClient implements PaymentVerificationPort {
+
+    @Override
+    public boolean verify(String purchaseToken) {
+        // TODO: Google Play purchases.products.get 연동 전까지 local/dev 검증용 스텁으로 사용한다.
+        return purchaseToken != null && !purchaseToken.isBlank();
+    }
+
+    @Override
+    public void consume(String purchaseToken) {
+        // Google Play consume API 연동 전까지는 서버 상태 전환 후 best-effort no-op으로 처리한다.
+    }
+
+    @Override
+    public String supportedPlatform() {
+        return "ANDROID";
+    }
+}

--- a/src/main/java/akuma/whiplash/infrastructure/payment/PaymentVerificationPort.java
+++ b/src/main/java/akuma/whiplash/infrastructure/payment/PaymentVerificationPort.java
@@ -1,0 +1,10 @@
+package akuma.whiplash.infrastructure.payment;
+
+public interface PaymentVerificationPort {
+
+    boolean verify(String paymentId);
+
+    void consume(String paymentId);
+
+    String supportedPlatform();
+}

--- a/src/main/resources/mysql.yml
+++ b/src/main/resources/mysql.yml
@@ -1,11 +1,12 @@
+spring:
+  jpa:
+    open-in-view: false
+
 ---
 spring.config.activate.on-profile: local
 
 spring:
   jpa:
-    database: MySQL
-    open-in-view: false
-    generate-ddl: false
     hibernate:
       ddl-auto: none
     show-sql: true

--- a/src/test/java/akuma/whiplash/common/fixture/AlarmFixture.java
+++ b/src/test/java/akuma/whiplash/common/fixture/AlarmFixture.java
@@ -79,6 +79,19 @@ public enum AlarmFixture {
             .build();
     }
 
+    public AlarmEntity toMockEntity(MemberEntity member) {
+        return AlarmEntity.builder()
+            .id(id)
+            .alarmPurpose(alarmPurpose)
+            .time(time)
+            .repeatDays(repeatDays)
+            .soundType(soundType)
+            .latitude(latitude)
+            .longitude(longitude)
+            .address(address)
+            .member(member)
+            .build();
+    }
 
     public AlarmEntity toEntity(MemberEntity member) {
         return AlarmEntity.builder()

--- a/src/test/java/akuma/whiplash/common/fixture/AlarmOccurrenceFixture.java
+++ b/src/test/java/akuma/whiplash/common/fixture/AlarmOccurrenceFixture.java
@@ -4,6 +4,7 @@ import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.Getter;
 
@@ -68,6 +69,33 @@ public enum AlarmOccurrenceFixture {
             .status(status)
             .alarmRinging(false)
             .ringingCount(0)
+            .reminderSent(false)
+            .build();
+    }
+
+    public AlarmOccurrenceEntity toMockEntity(AlarmEntity alarm, Long occurrenceId, LocalDateTime scheduledAt, OccurrenceStatus status) {
+        return AlarmOccurrenceEntity.builder()
+            .id(occurrenceId)
+            .alarm(alarm)
+            .occurrenceDate(scheduledAt.toLocalDate())
+            .occurrenceTime(scheduledAt.toLocalTime())
+            .scheduledAt(scheduledAt)
+            .status(status)
+            .alarmRinging(status == OccurrenceStatus.RINGING)
+            .ringingCount(status == OccurrenceStatus.RINGING ? 1 : 0)
+            .reminderSent(false)
+            .build();
+    }
+
+    public AlarmOccurrenceEntity toEntity(AlarmEntity alarm, LocalDateTime scheduledAt, OccurrenceStatus status) {
+        return AlarmOccurrenceEntity.builder()
+            .alarm(alarm)
+            .occurrenceDate(scheduledAt.toLocalDate())
+            .occurrenceTime(scheduledAt.toLocalTime())
+            .scheduledAt(scheduledAt)
+            .status(status)
+            .alarmRinging(status == OccurrenceStatus.RINGING)
+            .ringingCount(status == OccurrenceStatus.RINGING ? 1 : 0)
             .reminderSent(false)
             .build();
     }

--- a/src/test/java/akuma/whiplash/common/fixture/MemberDeviceFixture.java
+++ b/src/test/java/akuma/whiplash/common/fixture/MemberDeviceFixture.java
@@ -1,0 +1,34 @@
+package akuma.whiplash.common.fixture;
+
+import akuma.whiplash.domains.member.persistence.entity.MemberDeviceEntity;
+import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import lombok.Getter;
+
+@Getter
+public enum MemberDeviceFixture {
+
+    ANDROID("device-uuid", "ANDROID", "fcm-token"),
+    IOS("ios-device-uuid", "IOS", "ios-fcm-token");
+
+    private final String deviceId;
+    private final String platform;
+    private final String fcmToken;
+
+    MemberDeviceFixture(String deviceId, String platform, String fcmToken) {
+        this.deviceId = deviceId;
+        this.platform = platform;
+        this.fcmToken = fcmToken;
+    }
+
+    public MemberDeviceEntity toEntity(MemberEntity member) {
+        return MemberDeviceEntity.builder()
+            .member(member)
+            .deviceId(deviceId)
+            .platform(platform)
+            .fcmToken(fcmToken)
+            .isLoggedIn(true)
+            .appVersion("1.0.0")
+            .osVersion("17")
+            .build();
+    }
+}

--- a/src/test/java/akuma/whiplash/common/fixture/PaymentFixture.java
+++ b/src/test/java/akuma/whiplash/common/fixture/PaymentFixture.java
@@ -1,0 +1,36 @@
+package akuma.whiplash.common.fixture;
+
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.payment.domain.constant.PaymentStatus;
+import akuma.whiplash.domains.payment.domain.constant.PaymentType;
+import akuma.whiplash.domains.payment.persistence.entity.PaymentEntity;
+import lombok.Getter;
+
+@Getter
+public enum PaymentFixture {
+
+    STOP_ALARM_SUCCESS("payment-success-001", PaymentType.STOP_ALARM, PaymentStatus.SUCCESS),
+    STOP_ALARM_FAILED("payment-failed-001", PaymentType.STOP_ALARM, PaymentStatus.FAILED);
+
+    private final String paymentId;
+    private final PaymentType paymentType;
+    private final PaymentStatus status;
+
+    PaymentFixture(String paymentId, PaymentType paymentType, PaymentStatus status) {
+        this.paymentId = paymentId;
+        this.paymentType = paymentType;
+        this.status = status;
+    }
+
+    public PaymentEntity toEntity(MemberEntity member, AlarmEntity alarm) {
+        return PaymentEntity.builder()
+            .member(member)
+            .alarm(alarm)
+            .paymentId(paymentId)
+            .paymentType(paymentType)
+            .amount(0)
+            .status(status)
+            .build();
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -606,7 +606,7 @@ class AlarmCommandServiceTest {
             AlarmOccurrenceEntity occurrence = AlarmOccurrenceEntity.builder()
                     .id(1L)
                     .alarm(alarm)
-                    .occurrenceDate(LocalDate.now().minusDays(1)) // 과거 날짜 → 알람 시각 이미 지남
+                    .occurrenceDate(FIXED_NOW.toLocalDate().minusDays(1)) // 고정 시각 기준 과거 날짜
                     .occurrenceTime(LocalTime.of(0, 0))
                     .status(OccurrenceStatus.SCHEDULED)
                     .alarmRinging(false)
@@ -651,9 +651,12 @@ class AlarmCommandServiceTest {
             AlarmOccurrenceEntity occurrence = AlarmOccurrenceEntity.builder()
                 .id(1L)
                 .alarm(alarm)
-                .occurrenceDate(LocalDate.now().plusDays(1))  // 미래 날짜 → 아직 울릴 시간 아님
-                .occurrenceTime(LocalTime.now().plusHours(1))
-                .scheduledAt(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.now().plusHours(1)))
+                .occurrenceDate(FIXED_NOW.toLocalDate().plusDays(1))  // 고정 시각 기준 미래 날짜
+                .occurrenceTime(FIXED_NOW.toLocalTime().plusHours(1))
+                .scheduledAt(LocalDateTime.of(
+                    FIXED_NOW.toLocalDate().plusDays(1),
+                    FIXED_NOW.toLocalTime().plusHours(1)
+                ))
                 .status(OccurrenceStatus.SCHEDULED)
                 .alarmRinging(false)
                 .ringingCount(0)

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -7,40 +7,59 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
+import akuma.whiplash.common.fixture.AlarmOccurrenceFixture;
 import akuma.whiplash.common.fixture.AlarmFixture;
+import akuma.whiplash.common.fixture.MemberDeviceFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
+import akuma.whiplash.common.fixture.PaymentFixture;
 import akuma.whiplash.domains.alarm.application.event.AlarmCheckinCompletedEvent;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
+import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmDeactivationLogEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmDeactivationLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOffLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRingingLogRepository;
+import akuma.whiplash.domains.member.persistence.entity.MemberDeviceEntity;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.member.persistence.repository.MemberDeviceRepository;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
+import akuma.whiplash.domains.payment.domain.constant.PaymentStatus;
+import akuma.whiplash.domains.payment.persistence.entity.PaymentEntity;
+import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.service.ArchiveService;
+import akuma.whiplash.global.util.date.TimeProvider;
+import akuma.whiplash.infrastructure.payment.PaymentVerificationPort;
+import akuma.whiplash.infrastructure.redis.RingingAlarmRedisRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
-import akuma.whiplash.global.service.ArchiveService;
-import akuma.whiplash.infrastructure.redis.RingingAlarmRedisRepository;
-import org.springframework.context.ApplicationEventPublisher;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AlarmCommandService Unit Test")
@@ -55,16 +74,36 @@ class AlarmCommandServiceTest {
     @Mock
     private AlarmRingingLogRepository alarmRingingLogRepository;
     @Mock
+    private AlarmDeactivationLogRepository alarmDeactivationLogRepository;
+    @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private MemberDeviceRepository memberDeviceRepository;
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private List<PaymentVerificationPort> paymentVerificationPorts;
+    @Mock
+    private PaymentVerificationPort paymentVerificationPort;
     @Mock
     private RingingAlarmRedisRepository ringingAlarmRedisRepository;
     @Mock
     private ArchiveService archiveService;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private TimeProvider timeProvider;
 
     @InjectMocks
     private AlarmCommandServiceImpl alarmCommandService;
+
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 5, 2, 14, 30);
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(timeProvider.now()).thenReturn(FIXED_NOW);
+        lenient().when(timeProvider.today()).thenReturn(FIXED_NOW.toLocalDate());
+    }
 
     @Nested
     @DisplayName("createAlarm - 알람 등록")
@@ -319,6 +358,146 @@ class AlarmCommandServiceTest {
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
                 .isInstanceOf(ApplicationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateByPayment - 결제로 알람 끄기")
+    class DeactivateByPaymentTest {
+
+        @Test
+        @DisplayName("성공: 결제 검증이 완료되면 회차를 PAYMENT로 비활성화한다")
+        void success() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_15.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_15.toMockEntity(member);
+            AlarmOccurrenceEntity occurrence = AlarmOccurrenceFixture.ALARM_OCCURRENCE_02
+                .toMockEntity(alarm, 1001L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity nextOccurrence = AlarmOccurrenceFixture.ALARM_OCCURRENCE_02
+                .toMockEntity(alarm, 1002L, FIXED_NOW.plusDays(1), OccurrenceStatus.SCHEDULED);
+            MemberDeviceEntity device = MemberDeviceFixture.ANDROID.toEntity(member);
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                device.getDeviceId(),
+                "payment-success-001",
+                FIXED_NOW
+            );
+
+            given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
+            given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
+            given(paymentRepository.existsByPaymentId(request.paymentId())).willReturn(false);
+            given(memberDeviceRepository.findByMember_IdAndDeviceId(member.getId(), device.getDeviceId())).willReturn(Optional.of(device));
+            given(paymentVerificationPorts.stream()).willReturn(Stream.of(paymentVerificationPort));
+            given(paymentVerificationPort.supportedPlatform()).willReturn(device.getPlatform());
+            given(paymentVerificationPort.verify(request.paymentId())).willReturn(true);
+            given(alarmOccurrenceRepository.findNextScheduledByAlarmIds(eq(List.of(alarm.getId())), eq(OccurrenceStatus.SCHEDULED), eq(FIXED_NOW)))
+                .willReturn(List.of(nextOccurrence));
+
+            // when
+            AlarmPaymentResponse response = alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request);
+
+            // then
+            assertThat(occurrence.getStatus()).isEqualTo(OccurrenceStatus.PAYMENT);
+            assertThat(occurrence.getDeactivatedAt()).isEqualTo(FIXED_NOW);
+            assertThat(alarm.getRevision()).isEqualTo(2);
+            assertThat(response.alarmId()).isEqualTo(alarm.getId());
+            assertThat(response.deactivatedAt()).isEqualTo(FIXED_NOW);
+            assertThat(response.nextOccurrence().occurrenceId()).isEqualTo(nextOccurrence.getId());
+            verify(paymentRepository).save(any(PaymentEntity.class));
+            verify(alarmDeactivationLogRepository).save(any(AlarmDeactivationLogEntity.class));
+            verify(ringingAlarmRedisRepository).remove(alarm.getId(), member.getId());
+            verify(paymentVerificationPort).consume(request.paymentId());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 처리된 결제 ID이면 예외가 발생한다")
+        void fail_duplicatePayment() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_16.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_16.toMockEntity(member);
+            AlarmOccurrenceEntity occurrence = AlarmOccurrenceFixture.ALARM_OCCURRENCE_02
+                .toMockEntity(alarm, 1101L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                MemberDeviceFixture.ANDROID.getDeviceId(),
+                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId(),
+                FIXED_NOW
+            );
+
+            given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
+            given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
+            given(paymentRepository.existsByPaymentId(request.paymentId())).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage("이미 처리된 결제입니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 플랫폼 결제 검증이 실패하면 FAILED 결제와 실패 로그를 저장한다")
+        void fail_paymentVerificationFailed() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_17.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_17.toMockEntity(member);
+            AlarmOccurrenceEntity occurrence = AlarmOccurrenceFixture.ALARM_OCCURRENCE_02
+                .toMockEntity(alarm, 1201L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            MemberDeviceEntity device = MemberDeviceFixture.ANDROID.toEntity(member);
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                device.getDeviceId(),
+                PaymentFixture.STOP_ALARM_FAILED.getPaymentId(),
+                FIXED_NOW
+            );
+
+            given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
+            given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
+            given(paymentRepository.existsByPaymentId(request.paymentId())).willReturn(false);
+            given(memberDeviceRepository.findByMember_IdAndDeviceId(member.getId(), device.getDeviceId())).willReturn(Optional.of(device));
+            given(paymentVerificationPorts.stream()).willReturn(Stream.of(paymentVerificationPort));
+            given(paymentVerificationPort.supportedPlatform()).willReturn(device.getPlatform());
+            given(paymentVerificationPort.verify(request.paymentId())).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage("잘못된 요청입니다.");
+
+            ArgumentCaptor<PaymentEntity> paymentCaptor = ArgumentCaptor.forClass(PaymentEntity.class);
+            ArgumentCaptor<AlarmDeactivationLogEntity> logCaptor = ArgumentCaptor.forClass(AlarmDeactivationLogEntity.class);
+            verify(paymentRepository).save(paymentCaptor.capture());
+            verify(alarmDeactivationLogRepository).save(logCaptor.capture());
+            assertThat(paymentCaptor.getValue().getStatus()).isEqualTo(PaymentStatus.FAILED);
+            assertThat(logCaptor.getValue().getResult()).isEqualTo(DeactivationResult.FAIL);
+            assertThat(logCaptor.getValue().getFailReason())
+                .contains("PAYMENT_VERIFICATION_FAILED")
+                .contains("platform=ANDROID")
+                .contains("paymentId=" + request.paymentId())
+                .contains("reason=verification returned false");
+        }
+
+        @Test
+        @DisplayName("실패: 결제 가능 시간 전이면 예외가 발생한다")
+        void fail_notYetAvailable() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_18.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_18.toMockEntity(member);
+            AlarmOccurrenceEntity occurrence = AlarmOccurrenceFixture.ALARM_OCCURRENCE_02
+                .toMockEntity(alarm, 1301L, FIXED_NOW.plusHours(6), OccurrenceStatus.SCHEDULED);
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                MemberDeviceFixture.ANDROID.getDeviceId(),
+                "payment-not-yet-available",
+                FIXED_NOW
+            );
+
+            given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
+            given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
+
+            // when & then
+            assertThatThrownBy(() -> alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage("아직 위치 인증이 가능한 시간이 아닙니다.");
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -218,8 +218,8 @@ class AlarmCommandServiceTest {
                 .build();
         }
 
-        private AlarmCheckinRequest buildRequest(AlarmOccurrenceEntity occurrence, Double latitude, Double longitude, LocalDateTime requestedAt) {
-            return new AlarmCheckinRequest(occurrence.getId(), "device-uuid", latitude, longitude, requestedAt);
+        private AlarmCheckinRequest buildRequest(AlarmOccurrenceEntity occurrence, Double latitude, Double longitude) {
+            return new AlarmCheckinRequest(occurrence.getId(), "device-uuid", latitude, longitude);
         }
 
         @Test
@@ -237,7 +237,7 @@ class AlarmCommandServiceTest {
             given(alarmOccurrenceRepository.findNextScheduledByAlarmIds(eq(List.of(alarm.getId())), eq(OccurrenceStatus.SCHEDULED), any(LocalDateTime.class)))
                 .willReturn(List.of(nextOccurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
             // when
             AlarmCheckinResponse response = alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request);
@@ -262,7 +262,7 @@ class AlarmCommandServiceTest {
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(
                 1L,
                 1L,
-                new AlarmCheckinRequest(1L, "device-uuid", 0.0, 0.0, LocalDateTime.now())
+                new AlarmCheckinRequest(1L, "device-uuid", 0.0, 0.0)
             ))
                 .isInstanceOf(ApplicationException.class);
         }
@@ -277,7 +277,7 @@ class AlarmCommandServiceTest {
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
 
             AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 601L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(999L, alarm.getId(), request))
@@ -293,7 +293,7 @@ class AlarmCommandServiceTest {
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
             given(alarmOccurrenceRepository.findByIdAndAlarmId(999L, alarm.getId())).willReturn(Optional.empty());
 
-            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
+            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", alarm.getLatitude(), alarm.getLongitude());
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -312,7 +312,7 @@ class AlarmCommandServiceTest {
             occurrence.checkin(FIXED_NOW);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -333,8 +333,7 @@ class AlarmCommandServiceTest {
             AlarmCheckinRequest request = buildRequest(
                 occurrence,
                 alarm.getLatitude(),
-                alarm.getLongitude(),
-                occurrence.getScheduledAt().minusHours(4)
+                alarm.getLongitude()
             );
 
             // when & then
@@ -353,7 +352,7 @@ class AlarmCommandServiceTest {
             AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 901L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude() + 1, alarm.getLongitude() + 1, FIXED_NOW);
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude() + 1, alarm.getLongitude() + 1);
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -379,8 +378,7 @@ class AlarmCommandServiceTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 device.getDeviceId(),
-                "payment-success-001",
-                FIXED_NOW
+                "payment-success-001"
             );
 
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
@@ -420,8 +418,7 @@ class AlarmCommandServiceTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 MemberDeviceFixture.ANDROID.getDeviceId(),
-                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId(),
-                FIXED_NOW
+                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId()
             );
 
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
@@ -446,8 +443,7 @@ class AlarmCommandServiceTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 device.getDeviceId(),
-                PaymentFixture.STOP_ALARM_FAILED.getPaymentId(),
-                FIXED_NOW
+                PaymentFixture.STOP_ALARM_FAILED.getPaymentId()
             );
 
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
@@ -487,8 +483,7 @@ class AlarmCommandServiceTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 MemberDeviceFixture.ANDROID.getDeviceId(),
-                "payment-not-yet-available",
-                FIXED_NOW
+                "payment-not-yet-available"
             );
 
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -231,13 +231,13 @@ class AlarmCommandServiceTest {
             AlarmEntity alarm = buildAlarm(member, fixture);
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
 
-            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 501L, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
-            AlarmOccurrenceEntity nextOccurrence = buildOccurrence(alarm, 502L, LocalDateTime.now().plusDays(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 501L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity nextOccurrence = buildOccurrence(alarm, 502L, FIXED_NOW.plusDays(1), OccurrenceStatus.SCHEDULED);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
             given(alarmOccurrenceRepository.findNextScheduledByAlarmIds(eq(List.of(alarm.getId())), eq(OccurrenceStatus.SCHEDULED), any(LocalDateTime.class)))
                 .willReturn(List.of(nextOccurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
 
             // when
             AlarmCheckinResponse response = alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request);
@@ -276,8 +276,8 @@ class AlarmCommandServiceTest {
             AlarmEntity alarm = buildAlarm(owner, fixture);
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
 
-            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 601L, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 601L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(999L, alarm.getId(), request))
@@ -293,7 +293,7 @@ class AlarmCommandServiceTest {
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
             given(alarmOccurrenceRepository.findByIdAndAlarmId(999L, alarm.getId())).willReturn(Optional.empty());
 
-            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -308,11 +308,11 @@ class AlarmCommandServiceTest {
             AlarmFixture fixture = AlarmFixture.ALARM_13;
             AlarmEntity alarm = buildAlarm(member, fixture);
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
-            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 701L, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
-            occurrence.checkin(LocalDateTime.now());
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 701L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            occurrence.checkin(FIXED_NOW);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW);
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -327,7 +327,7 @@ class AlarmCommandServiceTest {
             AlarmFixture fixture = AlarmFixture.ALARM_14;
             AlarmEntity alarm = buildAlarm(member, fixture);
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
-            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 801L, LocalDateTime.now().plusHours(6), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 801L, FIXED_NOW.plusHours(6), OccurrenceStatus.SCHEDULED);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
 
             AlarmCheckinRequest request = buildRequest(
@@ -350,10 +350,10 @@ class AlarmCommandServiceTest {
             AlarmFixture fixture = AlarmFixture.ALARM_14;
             AlarmEntity alarm = buildAlarm(member, fixture);
             given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
-            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 901L, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 901L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
             given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId())).willReturn(Optional.of(occurrence));
 
-            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude() + 1, alarm.getLongitude() + 1, LocalDateTime.now());
+            AlarmCheckinRequest request = buildRequest(occurrence, alarm.getLatitude() + 1, alarm.getLongitude() + 1, FIXED_NOW);
 
             // when & then
             assertThatThrownBy(() -> alarmCommandService.checkinAlarm(member.getId(), alarm.getId(), request))
@@ -461,7 +461,7 @@ class AlarmCommandServiceTest {
             // when & then
             assertThatThrownBy(() -> alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage("잘못된 요청입니다.");
+                .hasMessage("결제 검증에 실패했습니다.");
 
             ArgumentCaptor<PaymentEntity> paymentCaptor = ArgumentCaptor.forClass(PaymentEntity.class);
             ArgumentCaptor<AlarmDeactivationLogEntity> logCaptor = ArgumentCaptor.forClass(AlarmDeactivationLogEntity.class);
@@ -497,7 +497,7 @@ class AlarmCommandServiceTest {
             // when & then
             assertThatThrownBy(() -> alarmCommandService.deactivateByPayment(member.getId(), alarm.getId(), request))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage("아직 위치 인증이 가능한 시간이 아닙니다.");
+                .hasMessage("아직 결제로 알람을 끌 수 있는 시간이 아닙니다.");
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import akuma.whiplash.domains.member.persistence.repository.MemberDeviceReposito
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
+import akuma.whiplash.global.util.date.TimeProvider;
 import akuma.whiplash.infrastructure.payment.PaymentVerificationPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.DayOfWeek;
@@ -39,6 +40,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -64,11 +66,19 @@ class AlarmControllerIntegrationTest {
     @Autowired private AlarmDeactivationLogRepository alarmDeactivationLogRepository;
     @Autowired private PaymentRepository paymentRepository;
     @MockitoBean private PaymentVerificationPort paymentVerificationPort;
+    @MockitoBean private TimeProvider timeProvider;
 
     private static final String BASE = "/api/v1/alarms";
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 5, 4, 11, 0);
+
+    @BeforeEach
+    void setUpTimeProvider() {
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+        given(timeProvider.today()).willReturn(FIXED_NOW.toLocalDate());
+    }
 
     private AlarmEntity saveAlarmForToday(MemberEntity member) {
-        DayOfWeek today = LocalDate.now().getDayOfWeek();
+        DayOfWeek today = FIXED_NOW.toLocalDate().getDayOfWeek();
         return alarmRepository.save(AlarmEntity.builder()
             .alarmPurpose("test")
             .time(LocalTime.of(7, 0))
@@ -82,7 +92,7 @@ class AlarmControllerIntegrationTest {
     }
 
     private AlarmEntity saveAlarmForNextWeek(MemberEntity member) {
-        DayOfWeek today = LocalDate.now().getDayOfWeek();
+        DayOfWeek today = FIXED_NOW.toLocalDate().getDayOfWeek();
         DayOfWeek previous = today.minus(1);
         return alarmRepository.save(AlarmEntity.builder()
             .alarmPurpose("test")
@@ -218,7 +228,7 @@ class AlarmControllerIntegrationTest {
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_1.toEntity());
             var alarm = alarmRepository.save(AlarmFixture.ALARM_01.toEntity(member));
 
-            var now = LocalDateTime.now();
+            var now = FIXED_NOW;
             var occurrence = AlarmOccurrenceEntity.builder()
                 .alarm(alarm)
                 .occurrenceDate(now.toLocalDate())
@@ -324,8 +334,8 @@ class AlarmControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_1.toEntity());
             AlarmEntity alarm = saveAlarmForToday(member);
-            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
-            saveOccurrence(alarm, LocalDateTime.now().plusDays(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            saveOccurrence(alarm, FIXED_NOW.plusDays(1), OccurrenceStatus.SCHEDULED);
             AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
             String accessToken = buildAccessToken(member);
 
@@ -366,7 +376,7 @@ class AlarmControllerIntegrationTest {
             MemberEntity owner = memberRepository.save(MemberFixture.MEMBER_3.toEntity());
             MemberEntity other = memberRepository.save(MemberFixture.MEMBER_4.toEntity());
             AlarmEntity alarm = saveAlarmForToday(owner);
-            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
             String accessToken = buildAccessToken(other);
             AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
@@ -384,8 +394,8 @@ class AlarmControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_5.toEntity());
             AlarmEntity alarm = saveAlarmForToday(member);
-            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
-            occurrence.checkin(LocalDateTime.now());
+            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            occurrence.checkin(FIXED_NOW);
             alarmOccurrenceRepository.save(occurrence);
             String accessToken = buildAccessToken(member);
             AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
@@ -404,7 +414,7 @@ class AlarmControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_6.toEntity());
             AlarmEntity alarm = saveAlarmForToday(member);
-            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
             String accessToken = buildAccessToken(member);
             AlarmCheckinRequest request = buildCheckinRequest(
                 occurrence,
@@ -426,7 +436,7 @@ class AlarmControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_7.toEntity());
             AlarmEntity alarm = saveAlarmForToday(member);
-            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(6), OccurrenceStatus.SCHEDULED);
+            AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, FIXED_NOW.plusHours(6), OccurrenceStatus.SCHEDULED);
             String accessToken = buildAccessToken(member);
             AlarmCheckinRequest request = buildCheckinRequest(
                 occurrence,
@@ -447,8 +457,6 @@ class AlarmControllerIntegrationTest {
     @DisplayName("deactivateByPayment - 결제로 알람 끄기")
     class DeactivateByPaymentTest {
 
-        private static final LocalDateTime PAYMENT_NOW = LocalDateTime.now();
-
         @Test
         @DisplayName("성공: 결제 요청이 성공하면 200 OK와 동기화 정보를 반환한다")
         void success() throws Exception {
@@ -457,7 +465,7 @@ class AlarmControllerIntegrationTest {
             memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
             AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_08.toEntity(member));
             AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
-                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
             );
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
@@ -492,7 +500,7 @@ class AlarmControllerIntegrationTest {
             memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
             AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_09.toEntity(member));
             AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
-                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
             );
             paymentRepository.save(PaymentFixture.STOP_ALARM_SUCCESS.toEntity(member, alarm));
             AlarmPaymentRequest request = new AlarmPaymentRequest(
@@ -519,7 +527,7 @@ class AlarmControllerIntegrationTest {
             memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
             AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_10.toEntity(member));
             AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
-                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(6), OccurrenceStatus.SCHEDULED)
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, FIXED_NOW.plusHours(6), OccurrenceStatus.SCHEDULED)
             );
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.domains.alarm.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -31,6 +32,7 @@ import akuma.whiplash.domains.member.persistence.repository.MemberDeviceReposito
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
+import akuma.whiplash.infrastructure.payment.PaymentVerificationPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -45,6 +47,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 @AutoConfigureMockMvc
@@ -60,6 +63,7 @@ class AlarmControllerIntegrationTest {
     @Autowired private AlarmOccurrenceRepository alarmOccurrenceRepository;
     @Autowired private AlarmDeactivationLogRepository alarmDeactivationLogRepository;
     @Autowired private PaymentRepository paymentRepository;
+    @MockitoBean private PaymentVerificationPort paymentVerificationPort;
 
     private static final String BASE = "/api/v1/alarms";
 
@@ -445,7 +449,7 @@ class AlarmControllerIntegrationTest {
     @DisplayName("deactivateByPayment - 결제로 알람 끄기")
     class DeactivateByPaymentTest {
 
-        private static final LocalDateTime PAYMENT_NOW = LocalDateTime.of(2026, 5, 2, 14, 30);
+        private static final LocalDateTime PAYMENT_NOW = LocalDateTime.now();
 
         @Test
         @DisplayName("성공: 결제 요청이 성공하면 200 OK와 동기화 정보를 반환한다")
@@ -464,6 +468,8 @@ class AlarmControllerIntegrationTest {
                 PAYMENT_NOW
             );
             String accessToken = buildAccessToken(member);
+            given(paymentVerificationPort.supportedPlatform()).willReturn(MemberDeviceFixture.ANDROID.getPlatform());
+            given(paymentVerificationPort.verify(request.paymentId())).willReturn(true);
 
             // when
             mockMvc.perform(post(BASE + "/{alarmId}/payment", alarm.getId())
@@ -533,7 +539,7 @@ class AlarmControllerIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("ALARM_013"));
+                .andExpect(jsonPath("$.code").value("PAYMENT_001"));
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -113,8 +113,8 @@ class AlarmControllerIntegrationTest {
             .build());
     }
 
-    private AlarmCheckinRequest buildCheckinRequest(AlarmOccurrenceEntity occurrence, Double latitude, Double longitude, LocalDateTime requestedAt) {
-        return new AlarmCheckinRequest(occurrence.getId(), "device-uuid", latitude, longitude, requestedAt);
+    private AlarmCheckinRequest buildCheckinRequest(AlarmOccurrenceEntity occurrence, Double latitude, Double longitude) {
+        return new AlarmCheckinRequest(occurrence.getId(), "device-uuid", latitude, longitude);
     }
 
     @Nested
@@ -326,7 +326,7 @@ class AlarmControllerIntegrationTest {
             AlarmEntity alarm = saveAlarmForToday(member);
             AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
             saveOccurrence(alarm, LocalDateTime.now().plusDays(1), OccurrenceStatus.SCHEDULED);
-            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
             String accessToken = buildAccessToken(member);
 
             // when
@@ -349,7 +349,7 @@ class AlarmControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_2.toEntity());
             String accessToken = buildAccessToken(member);
-            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", 0.0, 0.0, LocalDateTime.now());
+            AlarmCheckinRequest request = new AlarmCheckinRequest(999L, "device-uuid", 0.0, 0.0);
 
             // when & then
             mockMvc.perform(post(BASE + "/{alarmId}/checkin", 999L)
@@ -368,7 +368,7 @@ class AlarmControllerIntegrationTest {
             AlarmEntity alarm = saveAlarmForToday(owner);
             AlarmOccurrenceEntity occurrence = saveOccurrence(alarm, LocalDateTime.now().plusHours(1), OccurrenceStatus.SCHEDULED);
             String accessToken = buildAccessToken(other);
-            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
             // when & then
             mockMvc.perform(post(BASE + "/{alarmId}/checkin", alarm.getId())
@@ -388,7 +388,7 @@ class AlarmControllerIntegrationTest {
             occurrence.checkin(LocalDateTime.now());
             alarmOccurrenceRepository.save(occurrence);
             String accessToken = buildAccessToken(member);
-            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude(), LocalDateTime.now());
+            AlarmCheckinRequest request = buildCheckinRequest(occurrence, alarm.getLatitude(), alarm.getLongitude());
 
             // when & then
             mockMvc.perform(post(BASE + "/{alarmId}/checkin", alarm.getId())
@@ -409,8 +409,7 @@ class AlarmControllerIntegrationTest {
             AlarmCheckinRequest request = buildCheckinRequest(
                 occurrence,
                 alarm.getLatitude() + 1,
-                alarm.getLongitude() + 1,
-                LocalDateTime.now()
+                alarm.getLongitude() + 1
             );
 
             // when & then
@@ -432,8 +431,7 @@ class AlarmControllerIntegrationTest {
             AlarmCheckinRequest request = buildCheckinRequest(
                 occurrence,
                 alarm.getLatitude(),
-                alarm.getLongitude(),
-                occurrence.getScheduledAt().minusHours(4)
+                alarm.getLongitude()
             );
 
             // when & then
@@ -464,8 +462,7 @@ class AlarmControllerIntegrationTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 MemberDeviceFixture.ANDROID.getDeviceId(),
-                "integration-payment-success-001",
-                PAYMENT_NOW
+                "integration-payment-success-001"
             );
             String accessToken = buildAccessToken(member);
             given(paymentVerificationPort.supportedPlatform()).willReturn(MemberDeviceFixture.ANDROID.getPlatform());
@@ -501,8 +498,7 @@ class AlarmControllerIntegrationTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 MemberDeviceFixture.ANDROID.getDeviceId(),
-                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId(),
-                PAYMENT_NOW
+                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId()
             );
             String accessToken = buildAccessToken(member);
 
@@ -528,8 +524,7 @@ class AlarmControllerIntegrationTest {
             AlarmPaymentRequest request = new AlarmPaymentRequest(
                 occurrence.getId(),
                 MemberDeviceFixture.ANDROID.getDeviceId(),
-                "integration-payment-not-yet-available",
-                PAYMENT_NOW
+                "integration-payment-not-yet-available"
             );
             String accessToken = buildAccessToken(member);
 

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -10,8 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import akuma.whiplash.common.config.IntegrationTest;
 import akuma.whiplash.common.fixture.AlarmFixture;
 import akuma.whiplash.common.fixture.AlarmOccurrenceFixture;
+import akuma.whiplash.common.fixture.MemberDeviceFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
+import akuma.whiplash.common.fixture.PaymentFixture;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
+import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRemoveRequest;
 import akuma.whiplash.domains.alarm.application.mapper.AlarmMapper;
@@ -20,10 +23,13 @@ import akuma.whiplash.domains.alarm.domain.constant.SoundType;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmDeactivationLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
+import akuma.whiplash.domains.member.persistence.repository.MemberDeviceRepository;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
+import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.DayOfWeek;
@@ -49,8 +55,11 @@ class AlarmControllerIntegrationTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private MemberDeviceRepository memberDeviceRepository;
     @Autowired private AlarmRepository alarmRepository;
     @Autowired private AlarmOccurrenceRepository alarmOccurrenceRepository;
+    @Autowired private AlarmDeactivationLogRepository alarmDeactivationLogRepository;
+    @Autowired private PaymentRepository paymentRepository;
 
     private static final String BASE = "/api/v1/alarms";
 
@@ -429,6 +438,102 @@ class AlarmControllerIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateByPayment - 결제로 알람 끄기")
+    class DeactivateByPaymentTest {
+
+        private static final LocalDateTime PAYMENT_NOW = LocalDateTime.of(2026, 5, 2, 14, 30);
+
+        @Test
+        @DisplayName("성공: 결제 요청이 성공하면 200 OK와 동기화 정보를 반환한다")
+        void success() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_8.toEntity());
+            memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
+            AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_08.toEntity(member));
+            AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
+            );
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                MemberDeviceFixture.ANDROID.getDeviceId(),
+                "integration-payment-success-001",
+                PAYMENT_NOW
+            );
+            String accessToken = buildAccessToken(member);
+
+            // when
+            mockMvc.perform(post(BASE + "/{alarmId}/payment", alarm.getId())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.alarmId").value(alarm.getId()))
+                .andExpect(jsonPath("$.result.alarmRevision").value(2));
+
+            // then
+            AlarmOccurrenceEntity savedOccurrence = alarmOccurrenceRepository.findById(occurrence.getId()).orElseThrow();
+            assertThat(savedOccurrence.getStatus()).isEqualTo(OccurrenceStatus.PAYMENT);
+            assertThat(paymentRepository.existsByPaymentId(request.paymentId())).isTrue();
+            assertThat(alarmDeactivationLogRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("실패: 이미 처리된 결제 ID이면 409와 에러 코드를 반환한다")
+        void fail_duplicatePayment() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_9.toEntity());
+            memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
+            AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_09.toEntity(member));
+            AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(1), OccurrenceStatus.SCHEDULED)
+            );
+            paymentRepository.save(PaymentFixture.STOP_ALARM_SUCCESS.toEntity(member, alarm));
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                MemberDeviceFixture.ANDROID.getDeviceId(),
+                PaymentFixture.STOP_ALARM_SUCCESS.getPaymentId(),
+                PAYMENT_NOW
+            );
+            String accessToken = buildAccessToken(member);
+
+            // when & then
+            mockMvc.perform(post(BASE + "/{alarmId}/payment", alarm.getId())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PAYMENT_901"));
+        }
+
+        @Test
+        @DisplayName("실패: 결제 가능 시간 전이면 400과 에러 코드를 반환한다")
+        void fail_notYetAvailable() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_10.toEntity());
+            memberDeviceRepository.save(MemberDeviceFixture.ANDROID.toEntity(member));
+            AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_10.toEntity(member));
+            AlarmOccurrenceEntity occurrence = alarmOccurrenceRepository.save(
+                AlarmOccurrenceFixture.ALARM_OCCURRENCE_02.toEntity(alarm, PAYMENT_NOW.plusHours(6), OccurrenceStatus.SCHEDULED)
+            );
+            AlarmPaymentRequest request = new AlarmPaymentRequest(
+                occurrence.getId(),
+                MemberDeviceFixture.ANDROID.getDeviceId(),
+                "integration-payment-not-yet-available",
+                PAYMENT_NOW
+            );
+            String accessToken = buildAccessToken(member);
+
+            // when & then
+            mockMvc.perform(post(BASE + "/{alarmId}/payment", alarm.getId())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("ALARM_013"));
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
@@ -106,7 +106,7 @@ class AlarmControllerTest {
     }
 
     private AlarmCheckinRequest buildCheckinRequest() {
-        return new AlarmCheckinRequest(501L, "device-uuid", 37.0, 127.0, LocalDateTime.now());
+        return new AlarmCheckinRequest(501L, "device-uuid", 37.0, 127.0);
     }
 
     @AfterEach

--- a/src/test/java/akuma/whiplash/infrastructure/redis/RedisServiceTest.java
+++ b/src/test/java/akuma/whiplash/infrastructure/redis/RedisServiceTest.java
@@ -7,6 +7,7 @@ import akuma.whiplash.common.config.RedisContainerInitializer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +33,7 @@ class RedisServiceTest {
     @Autowired
     private RedisConnectionFactory connectionFactory;
 
+    @BeforeEach
     @AfterEach
     void clean() {
         try (RedisConnection conn = connectionFactory.getConnection()) {
@@ -46,7 +48,7 @@ class RedisServiceTest {
         @Test
         @DisplayName("성공: 새로운 토큰을 저장한다")
         void success_saveNewToken() {
-            Long memberId = 1L;
+            Long memberId = 101L;
             String deviceId = "deviceA";
             String token = "tokenA";
 
@@ -59,7 +61,7 @@ class RedisServiceTest {
         @Test
         @DisplayName("성공: 다른 토큰으로 교체하면 이전 토큰이 제거된다")
         void success_replaceToken() {
-            Long memberId = 1L;
+            Long memberId = 102L;
             String deviceId = "deviceB";
             redisService.upsertFcmToken(memberId, deviceId, "oldToken");
 
@@ -89,7 +91,7 @@ class RedisServiceTest {
         @DisplayName("성공: 동일 deviceId에 동시 요청이 와도 tokenCount가 1이다")
         void success_concurrentUpsertKeepsOneToken() throws InterruptedException {
             // given
-            Long memberId = 1L;
+            Long memberId = 103L;
             String deviceId = "shared-device";
             int threadCount = 10;
 


### PR DESCRIPTION
## 📄 PR 요약
> 인앱 결제를 통해 알람 회차를 비활성화하는 POST `/api/v1/alarms/{alarmId}/payment` API를 추가한다.
결제 도메인, 플랫폼별 결제 검증 포트, 결제/비활성화 로그 저장, 알람 회차 PAYMENT 상태 전환 및 관련 테스트를 구현했다.


## ✍🏻 PR 상세
1. 결제로 알람 끄기 API 추가

- `POST /api/v1/alarms/{alarmId}/payment`
- 알람/회차 소유자 검증
- 이미 처리된 회차 중복 비활성화 방지
- 알람 예정 시각 3시간 전부터 결제 비활성화 허용
- 결제 ID 중복 처리 시 `PAYMENT_901` 반환
- 성공 시 회차 상태를 `PAYMENT`로 변경하고 알람 revision 증가


2. 결제 도메인 추가

- `PaymentEntity`, `PaymentRepository`, `PaymentMapper` 추가
- `PaymentType`, `PaymentStatus`, `PaymentErrorCode` 추가
- 결제 성공/실패 상태를 DB에 저장하도록 구성

3. 플랫폼 결제 검증 구조 추가

- `PaymentVerificationPort` 추가
- Android / iOS용 결제 클라이언트 뼈대 추가
- 현재 Google Play / App Store 검증은 local/dev용 stub으로 구성
- 추후 실제 `purchases.products.get`, `consume` API 연동 가능하도록 분리


4. 알람 비활성화 로그 확장

- 결제 비활성화 타입 `PAYMENT` 추가
- 비활성화 결과 enum `DeactivationResult` 추가
- 결제 검증 실패 시
  - `payment (FAILED)`
  - `alarm_deactivation_log (FAIL)` 저장
- 실패 사유에 아래 정보 상세 기록
  - platform
  - paymentId
  - alarmId
  - occurrenceId
  - reason


5. 시간 처리 및 트랜잭션 보완

- `TimeProvider` 추가로 비즈니스 로직의 직접 `now()` 호출 제거
- `@Transactional(noRollbackFor = ApplicationException.class)` 적용
- OSIV 비활성화 설정 추가


6. Swagger 에러 코드 확장

- `CustomErrorCodes`에 `PaymentErrorCode` 지원 추가
- 결제 API 에러 코드 문서화
  - 결제 관련
  - 디바이스 관련
  - 공통 에러
  - 권한 에러


7. 테스트 추가

- 단위 테스트
  - 결제 성공
  - 중복 결제
  - 결제 검증 실패
  - 결제 가능 시간 전 케이스
- 통합 테스트
  - 결제 API 성공/실패 케이스
- 테스트 fixture 추가 및 기존 fixture 확장

👀 참고사항
- 현재 결제 검증 클라이언트는 실제 스토어 API 호출 전 단계의 stub임.
- 실제 Google Play 연동 시 paymentId는 purchaseToken, productId 기반으로 리팩터링해야함.
- ./gradlew build는 Sentry 토큰이 없으면 실패하므로 검증 시 -x sentryBundleSourcesJava 옵션이 필요


## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제로 알람을 해제하는 기능 추가 (결제 검증·처리 포함)
  * iOS(App Store) 및 Android(Google Play) 결제 검증 지원
  * 회원별 알람 조회 및 로컬-서버 동기화 API 추가

* **테스트**
  * 결제 기반 알람 해제 성공/실패 케이스 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->