### PR TITLE
알람 삭제 방법을 조회하는 API를 구현한다. 

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -6,7 +6,7 @@ description: >
 tools: Read, Grep, Glob
 ---
 
-당신은 Whiplash 프로젝트 아키텍처 리뷰어입니다.
+당신은 아키텍처 리뷰어입니다.
 
 ## 리뷰 절차
 1. 대상 파일을 Read로 읽는다.

--- a/.claude/agents/commit-helper.md
+++ b/.claude/agents/commit-helper.md
@@ -6,7 +6,7 @@ description: >
 tools: Bash
 ---
 
-당신은 Whiplash 프로젝트 커밋 메시지 작성 전문가입니다.
+당신은 커밋 메시지 작성 전문가입니다.
 
 ## 작업 순서
 

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -7,7 +7,7 @@ description: >
 tools: Read, Grep, Glob
 ---
 
-당신은 Whiplash 프로젝트 성능/메모리 리뷰어입니다.
+당신은 성능/메모리 리뷰어입니다.
 Java 17 + Spring Boot 3.5 + JPA + Redis 환경 기준으로 리뷰합니다.
 
 ## 리뷰 절차

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -6,7 +6,7 @@ description: >
 tools: Read, Grep, Glob
 ---
 
-당신은 Whiplash 프로젝트 테스트 컨벤션 리뷰어입니다.
+당신은 테스트 컨벤션 리뷰어입니다.
 
 ## 리뷰 절차
 

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmDeleteMethodResponse.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/response/AlarmDeleteMethodResponse.java
@@ -1,0 +1,9 @@
+package akuma.whiplash.domains.alarm.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AlarmDeleteMethodResponse(
+    String deleteMethod
+) {
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
@@ -2,6 +2,7 @@ package akuma.whiplash.domains.alarm.application.mapper;
 
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncItemDto;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
@@ -9,6 +10,7 @@ import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurren
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.NextOccurrenceResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPreviewDto;
+import akuma.whiplash.domains.alarm.domain.constant.AlarmDeleteMethod;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivateType;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
@@ -331,6 +333,12 @@ public class AlarmMapper {
         return AlarmSyncResponse.builder()
             .serverTime(serverTime)
             .alarms(alarms)
+            .build();
+    }
+
+    public static AlarmDeleteMethodResponse mapToAlarmDeleteMethodResponse(AlarmDeleteMethod deleteMethod) {
+        return AlarmDeleteMethodResponse.builder()
+            .deleteMethod(deleteMethod.name())
             .build();
     }
 

--- a/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/usecase/AlarmUseCase.java
@@ -6,6 +6,7 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmDeleteByPayment
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmOccurrenceResponse;
@@ -57,5 +58,9 @@ public class AlarmUseCase {
 
     public AlarmSyncResponse getSyncAlarms(Long memberId) {
         return alarmQueryService.getSyncAlarms(memberId);
+    }
+
+    public AlarmDeleteMethodResponse getAlarmDeleteMethod(Long memberId, Long alarmId) {
+        return alarmQueryService.getAlarmDeleteMethod(memberId, alarmId);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/constant/AlarmDeleteMethod.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/constant/AlarmDeleteMethod.java
@@ -1,0 +1,6 @@
+package akuma.whiplash.domains.alarm.domain.constant;
+
+public enum AlarmDeleteMethod {
+    AD,
+    PAYMENT
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryService.java
@@ -2,6 +2,7 @@ package akuma.whiplash.domains.alarm.domain.service;
 
 import akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo;
 import akuma.whiplash.domains.alarm.application.dto.etc.RingingPushInfo;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.GetAlarmsResponse;
 import java.time.LocalDateTime;
@@ -10,6 +11,7 @@ import java.util.List;
 public interface AlarmQueryService {
     GetAlarmsResponse getAlarms(Long memberId);
     AlarmSyncResponse getSyncAlarms(Long memberId);
+    AlarmDeleteMethodResponse getAlarmDeleteMethod(Long memberId, Long alarmId);
     List<OccurrencePushInfo> getPreNotificationTargets(LocalDateTime startInclusive, LocalDateTime endInclusive);
     List<RingingPushInfo> getRingingNotificationTargets();
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
@@ -1,10 +1,14 @@
 package akuma.whiplash.domains.alarm.domain.service;
 
+import static akuma.whiplash.domains.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
+
 import akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo;
 import akuma.whiplash.domains.alarm.application.dto.etc.RingingPushInfo;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.GetAlarmsResponse;
 import akuma.whiplash.domains.alarm.application.mapper.AlarmMapper;
+import akuma.whiplash.domains.alarm.domain.constant.AlarmDeleteMethod;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
@@ -12,10 +16,12 @@ import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.domains.auth.exception.AuthErrorCode;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.global.exception.ApplicationException;
 import akuma.whiplash.global.util.date.DateUtil;
+import akuma.whiplash.global.util.date.TimeProvider;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,6 +54,7 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     private final AlarmRepository alarmRepository;
     private final AlarmOccurrenceRepository alarmOccurrenceRepository;
     private final MemberRepository memberRepository;
+    private final TimeProvider timeProvider;
 
     @Override
     public GetAlarmsResponse getAlarms(Long memberId) {
@@ -161,6 +168,21 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     }
 
     @Override
+    public AlarmDeleteMethodResponse getAlarmDeleteMethod(Long memberId, Long alarmId) {
+        AlarmEntity alarm = findAlarmById(alarmId);
+        validAlarmOwner(memberId, alarm.getMember().getId());
+
+        AlarmDeleteMethod deleteMethod = alarmOccurrenceRepository
+            .findStatusByAlarmIdAndDate(alarmId, timeProvider.today())
+            .map(status -> requiresPayment(status)
+                ? AlarmDeleteMethod.PAYMENT
+                : AlarmDeleteMethod.AD)
+            .orElse(AlarmDeleteMethod.AD);
+
+        return AlarmMapper.mapToAlarmDeleteMethodResponse(deleteMethod);
+    }
+
+    @Override
     public List<OccurrencePushInfo> getPreNotificationTargets(LocalDateTime startInclusive, LocalDateTime endInclusive) {
         LocalDate startDate = startInclusive.toLocalDate();
         LocalTime startTime = startInclusive.toLocalTime();
@@ -190,5 +212,20 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     @Override
     public List<RingingPushInfo> getRingingNotificationTargets() {
         return alarmOccurrenceRepository.findRingingNotificationTargets();
+    }
+
+    private AlarmEntity findAlarmById(Long alarmId) {
+        return alarmRepository.findByIdWithMember(alarmId)
+            .orElseThrow(() -> ApplicationException.from(ALARM_NOT_FOUND));
+    }
+
+    private boolean requiresPayment(OccurrenceStatus status) {
+        return status == OccurrenceStatus.SCHEDULED || status == OccurrenceStatus.RINGING;
+    }
+
+    private static void validAlarmOwner(Long reqMemberId, Long alarmMemberId) {
+        if (!reqMemberId.equals(alarmMemberId)) {
+            throw ApplicationException.from(AuthErrorCode.PERMISSION_DENIED);
+        }
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
@@ -42,6 +42,17 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     );
 
     @Query("""
+    SELECT ao.status
+    FROM AlarmOccurrenceEntity ao
+    WHERE ao.alarm.id = :alarmId
+      AND ao.occurrenceDate = :date
+    """)
+    Optional<OccurrenceStatus> findStatusByAlarmIdAndDate(
+        @Param("alarmId") Long alarmId,
+        @Param("date") LocalDate date
+    );
+
+    @Query("""
     SELECT ao
     FROM AlarmOccurrenceEntity ao
     WHERE ao.id = :occurrenceId

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
@@ -3,12 +3,21 @@ package akuma.whiplash.domains.alarm.persistence.repository;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface AlarmRepository extends JpaRepository<AlarmEntity, Long> {
+
+    @Query("""
+        SELECT a
+        FROM AlarmEntity a
+        JOIN FETCH a.member
+        WHERE a.id = :alarmId
+    """)
+    Optional<AlarmEntity> findByIdWithMember(@Param("alarmId") Long alarmId);
 
     List<AlarmEntity> findAllByMemberId(Long memberId);
 

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -12,6 +12,7 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmDeleteByPayment
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmCheckinResponse;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
@@ -22,9 +23,11 @@ import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +37,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/alarms")
@@ -96,6 +100,21 @@ public class AlarmController {
     @GetMapping("/sync")
     public ApplicationResponse<AlarmSyncResponse> syncAlarms(@AuthenticationPrincipal MemberContext memberContext) {
         return ApplicationResponse.onSuccess(alarmUseCase.getSyncAlarms(memberContext.memberId()));
+    }
+
+    @CustomErrorCodes(
+        alarmErrorCodes = {ALARM_NOT_FOUND},
+        authErrorCodes = {PERMISSION_DENIED}
+    )
+    @Operation(summary = "알람 삭제 방법 조회", description = "알람 삭제 전 광고 시청(AD) 또는 벌금 납부(PAYMENT) 중 어떤 방법이 필요한지 조회합니다.")
+    @GetMapping("/{alarmId}/delete-method")
+    public ApplicationResponse<AlarmDeleteMethodResponse> getAlarmDeleteMethod(
+        @AuthenticationPrincipal MemberContext memberContext,
+        @PathVariable @Positive(message = "METHOD_ARGUMENT_NOT_VALID") Long alarmId
+    ) {
+        return ApplicationResponse.onSuccess(
+            alarmUseCase.getAlarmDeleteMethod(memberContext.memberId(), alarmId)
+        );
     }
 
     @CustomErrorCodes(

--- a/src/main/java/akuma/whiplash/global/config/security/RequestMatcherHolder.java
+++ b/src/main/java/akuma/whiplash/global/config/security/RequestMatcherHolder.java
@@ -54,10 +54,10 @@ public class RequestMatcherHolder {
         new RequestInfo(DELETE, "/api/load-test/**", null),
 
         // alarm
-        new RequestInfo(GET, "/api/alarms/**",USER),
-        new RequestInfo(POST, "/api/alarms/**",USER),
-        new RequestInfo(PUT, "/api/alarms/**",USER),
-        new RequestInfo(DELETE, "/api/alarms/**",USER),
+        new RequestInfo(GET, "/api/v1/alarms/**",USER),
+        new RequestInfo(POST, "/api/v1/alarms/**",USER),
+        new RequestInfo(PUT, "/api/v1/alarms/**",USER),
+        new RequestInfo(DELETE, "/api/v1/alarms/**",USER),
 
         // member
         new RequestInfo(GET, "/api/v1/members/**", USER),

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
@@ -11,20 +11,25 @@ import static org.mockito.Mockito.never;
 
 import akuma.whiplash.common.fixture.AlarmFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.GetAlarmsResponse;
+import akuma.whiplash.domains.alarm.domain.constant.AlarmDeleteMethod;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
+import akuma.whiplash.domains.alarm.exception.AlarmErrorCode;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.domains.auth.exception.AuthErrorCode;
 import akuma.whiplash.domains.member.exception.MemberErrorCode;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.util.date.TimeProvider;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -45,6 +50,7 @@ class AlarmQueryServiceTest {
     @Mock private AlarmRepository alarmRepository;
     @Mock private AlarmOccurrenceRepository alarmOccurrenceRepository;
     @Mock private MemberRepository memberRepository;
+    @Mock private TimeProvider timeProvider;
 
     @InjectMocks private AlarmQueryServiceImpl alarmQueryService;
 
@@ -255,6 +261,162 @@ class AlarmQueryServiceTest {
             thrown
                 .isInstanceOf(ApplicationException.class)
                 .hasFieldOrPropertyWithValue("code", MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAlarmDeleteMethod - 알람 삭제 방법 조회")
+    class GetAlarmDeleteMethodTest {
+
+        private static final LocalDate TODAY = LocalDate.of(2026, 5, 4);
+
+        @Nested
+        @DisplayName("오늘 회차가 없는 경우")
+        class NoOccurrenceTodayTest {
+
+            @Test
+            @DisplayName("성공: 광고 시청으로 삭제할 수 있다")
+            void success() {
+                // given
+                MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+                AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(member);
+                given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+                given(timeProvider.today()).willReturn(TODAY);
+                given(alarmOccurrenceRepository.findStatusByAlarmIdAndDate(alarm.getId(), TODAY))
+                    .willReturn(Optional.empty());
+
+                // when
+                AlarmDeleteMethodResponse result = alarmQueryService.getAlarmDeleteMethod(member.getId(), alarm.getId());
+
+                // then
+                assertThat(result.deleteMethod()).isEqualTo(AlarmDeleteMethod.AD.name());
+            }
+        }
+
+        @Nested
+        @DisplayName("오늘 회차가 도착 인증 완료 상태인 경우")
+        class CheckinCompletedTest {
+
+            @Test
+            @DisplayName("성공: 광고 시청으로 삭제할 수 있다")
+            void success() {
+                // given
+                MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+                AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(member);
+                given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+                given(timeProvider.today()).willReturn(TODAY);
+                given(alarmOccurrenceRepository.findStatusByAlarmIdAndDate(alarm.getId(), TODAY))
+                    .willReturn(Optional.of(OccurrenceStatus.CHECKIN));
+
+                // when
+                AlarmDeleteMethodResponse result = alarmQueryService.getAlarmDeleteMethod(member.getId(), alarm.getId());
+
+                // then
+                assertThat(result.deleteMethod()).isEqualTo(AlarmDeleteMethod.AD.name());
+            }
+        }
+
+        @Nested
+        @DisplayName("오늘 회차가 결제 완료 상태인 경우")
+        class PaymentCompletedTest {
+
+            @Test
+            @DisplayName("성공: 광고 시청으로 삭제할 수 있다")
+            void success() {
+                // given
+                MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+                AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(member);
+                given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+                given(timeProvider.today()).willReturn(TODAY);
+                given(alarmOccurrenceRepository.findStatusByAlarmIdAndDate(alarm.getId(), TODAY))
+                    .willReturn(Optional.of(OccurrenceStatus.PAYMENT));
+
+                // when
+                AlarmDeleteMethodResponse result = alarmQueryService.getAlarmDeleteMethod(member.getId(), alarm.getId());
+
+                // then
+                assertThat(result.deleteMethod()).isEqualTo(AlarmDeleteMethod.AD.name());
+            }
+        }
+
+        @Nested
+        @DisplayName("오늘 회차가 예정 상태인 경우")
+        class ScheduledTest {
+
+            @Test
+            @DisplayName("성공: 결제로 삭제할 수 있다")
+            void success() {
+                // given
+                MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+                AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(member);
+                given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+                given(timeProvider.today()).willReturn(TODAY);
+                given(alarmOccurrenceRepository.findStatusByAlarmIdAndDate(alarm.getId(), TODAY))
+                    .willReturn(Optional.of(OccurrenceStatus.SCHEDULED));
+
+                // when
+                AlarmDeleteMethodResponse result = alarmQueryService.getAlarmDeleteMethod(member.getId(), alarm.getId());
+
+                // then
+                assertThat(result.deleteMethod()).isEqualTo(AlarmDeleteMethod.PAYMENT.name());
+            }
+        }
+
+        @Nested
+        @DisplayName("오늘 회차가 울림 상태인 경우")
+        class RingingTest {
+
+            @Test
+            @DisplayName("성공: 결제로 삭제할 수 있다")
+            void success() {
+                // given
+                MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+                AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(member);
+                given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+                given(timeProvider.today()).willReturn(TODAY);
+                given(alarmOccurrenceRepository.findStatusByAlarmIdAndDate(alarm.getId(), TODAY))
+                    .willReturn(Optional.of(OccurrenceStatus.RINGING));
+
+                // when
+                AlarmDeleteMethodResponse result = alarmQueryService.getAlarmDeleteMethod(member.getId(), alarm.getId());
+
+                // then
+                assertThat(result.deleteMethod()).isEqualTo(AlarmDeleteMethod.PAYMENT.name());
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 알람이 존재하지 않으면 예외를 던진다")
+        void fail_alarmNotFound() {
+            // given
+            long alarmId = 999L;
+            given(alarmRepository.findByIdWithMember(alarmId)).willReturn(Optional.empty());
+
+            // when
+            var thrown = assertThatThrownBy(() -> alarmQueryService.getAlarmDeleteMethod(1L, alarmId));
+
+            // then
+            thrown
+                .isInstanceOfSatisfying(ApplicationException.class, e ->
+                    assertThat(e.getCode()).isEqualTo(AlarmErrorCode.ALARM_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("실패: 알람 소유자가 아니면 예외를 던진다")
+        void fail_permissionDenied() {
+            // given
+            MemberEntity owner = MemberFixture.MEMBER_11.toMockEntity();
+            MemberEntity other = MemberFixture.MEMBER_12.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity(owner);
+            given(alarmRepository.findByIdWithMember(alarm.getId())).willReturn(Optional.of(alarm));
+
+            // when
+            var thrown = assertThatThrownBy(() -> alarmQueryService.getAlarmDeleteMethod(other.getId(), alarm.getId()));
+
+            // then
+            thrown
+                .isInstanceOfSatisfying(ApplicationException.class, e ->
+                    assertThat(e.getCode()).isEqualTo(AuthErrorCode.PERMISSION_DENIED));
         }
     }
 }

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -21,11 +21,8 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmDeleteByPayment
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
 import akuma.whiplash.domains.alarm.application.mapper.AlarmMapper;
-import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
-import akuma.whiplash.domains.alarm.domain.constant.DeleteType;
-import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
-import akuma.whiplash.domains.alarm.domain.constant.SoundType;
-import akuma.whiplash.domains.alarm.domain.constant.Weekday;
+import akuma.whiplash.domains.alarm.domain.constant.*;
+import akuma.whiplash.domains.alarm.exception.AlarmErrorCode;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmOccurrenceEntity;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmDeactivationLogRepository;
@@ -33,6 +30,7 @@ import akuma.whiplash.domains.alarm.persistence.repository.AlarmDeleteLogReposit
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRingingLogRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmOccurrenceRepository;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.domains.auth.exception.AuthErrorCode;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberDeviceRepository;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
@@ -711,6 +709,97 @@ class AlarmControllerIntegrationTest {
 
             assertThat(paymentRepository.existsByPaymentId(request.paymentId())).isTrue();
             assertThat(alarmDeleteLogRepository.findAll()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAlarmDeleteMethod - 알람 삭제 방법 조회")
+    class GetAlarmDeleteMethodTest {
+
+        @Nested
+        @DisplayName("오늘 회차가 없는 경우")
+        class NoOccurrenceTodayTest {
+
+            @Test
+            @DisplayName("성공: 광고 삭제 방법을 반환한다")
+            void success() throws Exception {
+                // given
+                MemberEntity member = memberRepository.save(MemberFixture.MEMBER_11.toEntity());
+                AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_11.toEntity(member));
+                String accessToken = buildAccessToken(member);
+
+                // when
+                var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", alarm.getId())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+                // then
+                result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.deleteMethod").value(AlarmDeleteMethod.AD.name()))
+                    .andExpect(jsonPath("$.result.alarmId").doesNotExist());
+            }
+        }
+
+        @Nested
+        @DisplayName("오늘 회차가 예정 상태인 경우")
+        class ScheduledTest {
+
+            @Test
+            @DisplayName("성공: 결제 삭제 방법을 반환한다")
+            void success() throws Exception {
+                // given
+                MemberEntity member = memberRepository.save(MemberFixture.MEMBER_12.toEntity());
+                AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_12.toEntity(member));
+                saveOccurrence(alarm, FIXED_NOW, OccurrenceStatus.SCHEDULED);
+                String accessToken = buildAccessToken(member);
+
+                // when
+                var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", alarm.getId())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+                // then
+                result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.deleteMethod").value(AlarmDeleteMethod.PAYMENT.name()));
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 알람이 존재하지 않으면 404를 반환한다")
+        void fail_alarmNotFound() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_13.toEntity());
+            String accessToken = buildAccessToken(member);
+
+            // when
+            var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 999L)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+            // then
+            result
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AlarmErrorCode.ALARM_NOT_FOUND.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 소유자가 아니면 403을 반환한다")
+        void fail_permissionDenied() throws Exception {
+            // given
+            MemberEntity owner = memberRepository.save(MemberFixture.MEMBER_14.toEntity());
+            MemberEntity other = memberRepository.save(MemberFixture.MEMBER_15.toEntity());
+            AlarmEntity alarm = alarmRepository.save(AlarmFixture.ALARM_14.toEntity(owner));
+            String accessToken = buildAccessToken(other);
+
+            // when
+            var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", alarm.getId())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+            // then
+            result
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.PERMISSION_DENIED.getCustomCode()));
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
@@ -21,12 +21,14 @@ import akuma.whiplash.domains.alarm.application.dto.request.AlarmCheckinRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmDeleteByAdRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmDeleteByPaymentRequest;
 import akuma.whiplash.domains.alarm.application.dto.request.AlarmRegisterRequest;
+import akuma.whiplash.domains.alarm.application.dto.response.AlarmDeleteMethodResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmPreviewDto;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncItemDto;
 import akuma.whiplash.domains.alarm.application.dto.response.AlarmSyncResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import akuma.whiplash.domains.alarm.application.dto.response.GetAlarmsResponse;
 import akuma.whiplash.domains.alarm.application.usecase.AlarmUseCase;
+import akuma.whiplash.domains.alarm.domain.constant.AlarmDeleteMethod;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.exception.AlarmErrorCode;
 import akuma.whiplash.domains.auth.application.dto.etc.MemberContext;
@@ -36,6 +38,7 @@ import akuma.whiplash.domains.payment.exception.PaymentErrorCode;
 import akuma.whiplash.global.config.security.SecurityConfig;
 import akuma.whiplash.global.config.security.jwt.JwtAuthenticationFilter;
 import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.response.code.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -560,6 +563,114 @@ class AlarmControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("getAlarmDeleteMethod - 알람 삭제 방법 조회")
+    class GetAlarmDeleteMethodTest {
+
+        @Nested
+        @DisplayName("광고 삭제 방법인 경우")
+        class AdMethodTest {
+
+            @Test
+            @DisplayName("성공: 광고 삭제 방법을 반환한다")
+            void success() throws Exception {
+                // given
+                setSecurityContext(buildContext(MEMBER_5));
+                when(alarmUseCase.getAlarmDeleteMethod(MEMBER_5.getId(), 1L))
+                    .thenReturn(AlarmDeleteMethodResponse.builder()
+                        .deleteMethod(AlarmDeleteMethod.AD.name())
+                        .build());
+
+                // when
+                var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 1L));
+
+                // then
+                result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.deleteMethod").value(AlarmDeleteMethod.AD.name()))
+                    .andExpect(jsonPath("$.result.alarmId").doesNotExist());
+                verify(alarmUseCase, times(1)).getAlarmDeleteMethod(MEMBER_5.getId(), 1L);
+            }
+        }
+
+        @Nested
+        @DisplayName("결제 삭제 방법인 경우")
+        class PaymentMethodTest {
+
+            @Test
+            @DisplayName("성공: 결제 삭제 방법을 반환한다")
+            void success() throws Exception {
+                // given
+                setSecurityContext(buildContext(MEMBER_5));
+                when(alarmUseCase.getAlarmDeleteMethod(MEMBER_5.getId(), 1L))
+                    .thenReturn(AlarmDeleteMethodResponse.builder()
+                        .deleteMethod(AlarmDeleteMethod.PAYMENT.name())
+                        .build());
+
+                // when
+                var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 1L));
+
+                // then
+                result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.deleteMethod").value(AlarmDeleteMethod.PAYMENT.name()));
+                verify(alarmUseCase, times(1)).getAlarmDeleteMethod(MEMBER_5.getId(), 1L);
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 알람이 존재하지 않으면 404를 반환한다")
+        void fail_alarmNotFound() throws Exception {
+            // given
+            setSecurityContext(buildContext(MEMBER_6));
+            doThrow(ApplicationException.from(AlarmErrorCode.ALARM_NOT_FOUND))
+                .when(alarmUseCase).getAlarmDeleteMethod(anyLong(), anyLong());
+
+            // when
+            var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 1L));
+
+            // then
+            result
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AlarmErrorCode.ALARM_NOT_FOUND.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 소유자가 아니면 403을 반환한다")
+        void fail_permissionDenied() throws Exception {
+            // given
+            setSecurityContext(buildContext(MEMBER_7));
+            doThrow(ApplicationException.from(AuthErrorCode.PERMISSION_DENIED))
+                .when(alarmUseCase).getAlarmDeleteMethod(anyLong(), anyLong());
+
+            // when
+            var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 1L));
+
+            // then
+            result
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.PERMISSION_DENIED.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 알람 ID가 양수가 아니면 400을 반환한다")
+        void fail_alarmIdNotPositive() throws Exception {
+            // given
+            setSecurityContext(buildContext(MEMBER_7));
+
+            // when
+            var result = mockMvc.perform(get(BASE + "/{alarmId}/delete-method", 0L));
+
+            // then
+            result
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.METHOD_ARGUMENT_NOT_VALID.getCustomCode()));
         }
     }
 


### PR DESCRIPTION
## 📄 PR 요약
> 알람 삭제 전 필요한 삭제 방법을 조회하는 API를 추가

## ✍🏻 PR 상세
1. GET /api/v1/alarms/{alarmId}/delete-method API 추가
   - 오늘 회차가 없거나 이미 처리된 상태이면 `AD` 반환
   - 오늘 회차가 `SCHEDULED` 또는 `RINGING` 이면 `PAYMENT` 반환
   - 알람 소유자 검증 및 알람 ID 양수 검증 추가

2. 조회 성능 개선
   - 알람 조회 시 `member` 를 fetch join으로 함께 조회해 lazy 추가 쿼리 방지
   - 오늘 회차 조회는 전체 엔티티 대신 `OccurrenceStatus` 만 projection으로 조회

3. 보안 매처 경로 수정
   - 알람 API 보안 매처를 `/api/alarms/**` 에서 실제 경로인 `/api/v1/alarms/**` 로 수정

4. 테스트 추가
   - QueryService 단위 테스트 추가
   - Controller slice 테스트 추가
   - Controller integration 테스트 추가
   - AD/PAYMENT 성공 케이스와 400/403/404 실패 케이스 검증

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알람 삭제 방법 조회 기능 추가 - 사용자가 특정 알람을 삭제하기 위해 필요한 방법(광고 또는 결제)을 확인할 수 있습니다.

* **Tests**
  * 알람 삭제 방법 조회 기능에 대한 단위 및 통합 테스트 추가.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Central-MakeUs/Whiplash-Server/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->