### PR TITLE
장소 검색 관련 API를 개선한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/place/application/dto/response/PlaceDetailResponse.java
+++ b/src/main/java/akuma/whiplash/domains/place/application/dto/response/PlaceDetailResponse.java
@@ -5,5 +5,6 @@ import lombok.Builder;
 @Builder
 public record PlaceDetailResponse(
     String address,
-    String name
+    String placeName,
+    String roadAddress
 ) {}

--- a/src/main/java/akuma/whiplash/domains/place/application/dto/response/PlaceInfoResponse.java
+++ b/src/main/java/akuma/whiplash/domains/place/application/dto/response/PlaceInfoResponse.java
@@ -1,5 +1,6 @@
 package akuma.whiplash.domains.place.application.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
@@ -7,5 +8,7 @@ public record PlaceInfoResponse(
     String name,
     String address,
     double latitude,
-    double longitude
+    double longitude,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    Integer distanceMeters
 ) {}

--- a/src/main/java/akuma/whiplash/domains/place/application/usecase/PlaceUseCase.java
+++ b/src/main/java/akuma/whiplash/domains/place/application/usecase/PlaceUseCase.java
@@ -4,8 +4,11 @@ import akuma.whiplash.domains.place.application.dto.response.PlaceInfoResponse;
 import akuma.whiplash.domains.place.application.dto.response.PlaceDetailResponse;
 import akuma.whiplash.domains.place.domain.service.PlaceQueryService;
 import akuma.whiplash.global.annotation.architecture.UseCase;
+import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.response.code.CommonErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @UseCase
 @RequiredArgsConstructor
@@ -13,8 +16,9 @@ public class PlaceUseCase {
 
     private final PlaceQueryService placeQueryService;
 
-    public List<PlaceInfoResponse> searchPlaces(String query) {
-        return placeQueryService.searchPlaces(query);
+    public List<PlaceInfoResponse> searchPlaces(String query, Double latitude, Double longitude) {
+        validateSearchRequest(query, latitude, longitude);
+        return placeQueryService.searchPlaces(query, latitude, longitude);
     }
 
     public PlaceDetailResponse getPlaceDetail(double latitude, double longitude) {
@@ -23,5 +27,15 @@ public class PlaceUseCase {
 
     public List<String> searchPlaceKeywords(String query) {
         return placeQueryService.searchPlaceKeywords(query);
+    }
+
+    private void validateSearchRequest(String query, Double latitude, Double longitude) {
+        if (!StringUtils.hasText(query)) {
+            throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+        }
+
+        if ((latitude == null) != (longitude == null)) {
+            throw ApplicationException.from(CommonErrorCode.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
@@ -14,13 +14,14 @@ import org.springframework.stereotype.Service;
 public class MockPlaceQueryService implements PlaceQueryService {
 
     @Override
-    public List<PlaceInfoResponse> searchPlaces(String query) {
+    public List<PlaceInfoResponse> searchPlaces(String query, Double latitude, Double longitude) {
         return IntStream.range(1, 6)
             .mapToObj(i -> PlaceInfoResponse.builder()
                 .name("Mock Place " + i + " for " + query)
                 .address("Seoul, Gangnam-gu, Teheran-ro " + i)
                 .latitude(37.4979 + (i * 0.001))
                 .longitude(127.0276 + (i * 0.001))
+                .distanceMeters(calculateMockDistance(latitude, longitude, i))
                 .build())
             .toList();
     }
@@ -36,5 +37,12 @@ public class MockPlaceQueryService implements PlaceQueryService {
     @Override
     public List<String> searchPlaceKeywords(String query) {
         return List.of(query + " station", query + " park", query + " school");
+    }
+
+    private Integer calculateMockDistance(Double latitude, Double longitude, int index) {
+        if (latitude == null || longitude == null) {
+            return null;
+        }
+        return index * 100;
     }
 }

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 @Service
-@Profile("local")
+@Profile({"local", "test"})
 @Primary
 public class MockPlaceQueryService implements PlaceQueryService {
 

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/MockPlaceQueryService.java
@@ -29,8 +29,9 @@ public class MockPlaceQueryService implements PlaceQueryService {
     @Override
     public PlaceDetailResponse getPlaceDetailByCoord(double latitude, double longitude) {
         return PlaceDetailResponse.builder()
-            .name("Mock Detail Place")
+            .placeName("Mock Detail Place")
             .address("Seoul, Gangnam-gu, Mock-ro 123")
+            .roadAddress("Seoul, Gangnam-gu, Mock-ro 123")
             .build();
     }
 

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryService.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface PlaceQueryService {
 
-    List<PlaceInfoResponse> searchPlaces(String query);
+    List<PlaceInfoResponse> searchPlaces(String query, Double latitude, Double longitude);
     PlaceDetailResponse getPlaceDetailByCoord(double latitude, double longitude);
     List<String> searchPlaceKeywords(String query);
 }

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
@@ -7,6 +7,7 @@ import akuma.whiplash.domains.place.application.dto.response.ReverseGeocodeApiRe
 import akuma.whiplash.domains.place.application.dto.response.PlaceDetailResponse;
 import akuma.whiplash.global.exception.ApplicationException;
 import akuma.whiplash.global.response.code.CommonErrorCode;
+import akuma.whiplash.global.util.GeoUtils;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -50,7 +51,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     private static final String NCP_REVERSE_GEOCODE_URL = "https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc";
 
     @Override
-    public List<PlaceInfoResponse> searchPlaces(String query) {
+    public List<PlaceInfoResponse> searchPlaces(String query, Double latitude, Double longitude) {
         String uri = UriComponentsBuilder
             .fromUriString(NAVER_LOCAL_SEARCH_URL)
             .queryParam("query", query)
@@ -69,13 +70,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
         if (response == null || response.getItems() == null) return List.of();
 
         return response.getItems().stream()
-            .map(item -> PlaceInfoResponse.builder()
-                .name(sanitize(item.getTitle()))
-                .address(item.getAddress())
-                .latitude(parseDouble(item.getMapy()) / 1e7)
-                .longitude(parseDouble(item.getMapx()) / 1e7)
-                .build()
-            )
+            .map(item -> mapToPlaceInfoResponse(item, latitude, longitude))
             .toList();
     }
 
@@ -171,6 +166,33 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
         if (address == null) return Optional.empty();
         Matcher matcher = pattern.matcher(address);
         return matcher.find() ? Optional.of(matcher.group()) : Optional.empty();
+    }
+
+    private PlaceInfoResponse mapToPlaceInfoResponse(NaverPlaceItem item, Double requestLatitude, Double requestLongitude) {
+        double placeLatitude = parseDouble(item.getMapy()) / 1e7;
+        double placeLongitude = parseDouble(item.getMapx()) / 1e7;
+
+        return PlaceInfoResponse.builder()
+            .name(sanitize(item.getTitle()))
+            .address(resolveDisplayAddress(item))
+            .latitude(placeLatitude)
+            .longitude(placeLongitude)
+            .distanceMeters(calculateDistanceMeters(requestLatitude, requestLongitude, placeLatitude, placeLongitude))
+            .build();
+    }
+
+    private String resolveDisplayAddress(NaverPlaceItem item) {
+        if (item.getRoadAddress() != null && !item.getRoadAddress().isBlank()) {
+            return item.getRoadAddress();
+        }
+        return item.getAddress() != null ? item.getAddress() : "";
+    }
+
+    private Integer calculateDistanceMeters(Double requestLatitude, Double requestLongitude, double placeLatitude, double placeLongitude) {
+        if (requestLatitude == null || requestLongitude == null) {
+            return null;
+        }
+        return GeoUtils.calculateDistanceMeters(requestLatitude, requestLongitude, placeLatitude, placeLongitude);
     }
 
     private String sanitize(String html) {

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
@@ -21,11 +21,13 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
+@Profile("!local & !test")
 @RequiredArgsConstructor
 @Slf4j
 public class PlaceQueryServiceImpl implements PlaceQueryService {
@@ -44,14 +46,16 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Value("${naver.map.client-secret}")
     private String ncpClientSecret;
 
-    private static final String NAVER_LOCAL_SEARCH_URL = "https://openapi.naver.com/v1/search/local.json";
+    @Value("${naver.search.base-url:https://openapi.naver.com/v1/search/local.json}")
+    private String naverLocalSearchUrl;
 
-    private static final String NCP_REVERSE_GEOCODE_URL = "https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc";
+    @Value("${naver.map.reverse-geocode-url:https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc}")
+    private String ncpReverseGeocodeUrl;
 
     @Override
     public List<PlaceInfoResponse> searchPlaces(String query, Double latitude, Double longitude) {
         String uri = UriComponentsBuilder
-            .fromUriString(NAVER_LOCAL_SEARCH_URL)
+            .fromUriString(naverLocalSearchUrl)
             .queryParam("query", query)
             .queryParam("display", "5")
             .build()
@@ -75,7 +79,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Override
     public PlaceDetailResponse getPlaceDetailByCoord(double latitude, double longitude) {
         String uri = UriComponentsBuilder
-            .fromUriString(NCP_REVERSE_GEOCODE_URL)
+            .fromUriString(ncpReverseGeocodeUrl)
             .queryParam("coords", longitude + "," + latitude)
             .queryParam("output", "json")
             .queryParam("orders", "roadaddr,addr")
@@ -133,7 +137,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Override
     public List<String> searchPlaceKeywords(String query) {
         String uri = UriComponentsBuilder
-            .fromUriString(NAVER_LOCAL_SEARCH_URL)
+            .fromUriString(naverLocalSearchUrl)
             .queryParam("query", query)
             .queryParam("display", "5")
             .build()

--- a/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceImpl.java
@@ -22,11 +22,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -127,7 +125,8 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
 
         return PlaceDetailResponse.builder()
             .address(fullAddress)
-            .name(placeName != null ? placeName : "장소 없음")
+            .placeName(placeName != null ? placeName : "장소 없음")
+            .roadAddress(fullAddress)
             .build();
     }
 

--- a/src/main/java/akuma/whiplash/domains/place/presentation/PlaceController.java
+++ b/src/main/java/akuma/whiplash/domains/place/presentation/PlaceController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/places")
+@RequestMapping("/api/v1/places")
 public class PlaceController {
 
     private final PlaceUseCase placeUseCase;
@@ -25,8 +25,12 @@ public class PlaceController {
     @CustomErrorCodes(commonErrorCodes = {BAD_REQUEST})
     @Operation(summary = "장소 목록 검색", description = "키워드 기반 장소 검색을 제공합니다.")
     @GetMapping("/search")
-    public ApplicationResponse<List<PlaceInfoResponse>> searchPlaces(@RequestParam String query) {
-        List<PlaceInfoResponse> placeInfoResponses = placeUseCase.searchPlaces(query);
+    public ApplicationResponse<List<PlaceInfoResponse>> searchPlaces(
+        @RequestParam String query,
+        @RequestParam(required = false) Double latitude,
+        @RequestParam(required = false) Double longitude
+    ) {
+        List<PlaceInfoResponse> placeInfoResponses = placeUseCase.searchPlaces(query, latitude, longitude);
         return ApplicationResponse.onSuccess(placeInfoResponses);
     }
 

--- a/src/main/java/akuma/whiplash/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/akuma/whiplash/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -105,6 +106,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             LogUtils.maskSensitiveQuery(extractQueryString(request)),
             CommonErrorCode.METHOD_ARGUMENT_NOT_VALID.getCustomCode(),
             CommonErrorCode.METHOD_ARGUMENT_NOT_VALID.getHttpStatus()
+        );
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+        MissingServletRequestParameterException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        sendErrorToSentry(
+            ex,
+            extractRequestUri(request),
+            LogUtils.maskSensitiveQuery(extractQueryString(request)),
+            CommonErrorCode.BAD_REQUEST.getCustomCode(),
+            CommonErrorCode.BAD_REQUEST.getHttpStatus()
+        );
+
+        ApplicationResponse<Void> response = ApplicationResponse.onFailure(
+            CommonErrorCode.BAD_REQUEST.getCustomCode(),
+            CommonErrorCode.BAD_REQUEST.getMessage()
         );
 
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);

--- a/src/main/java/akuma/whiplash/global/util/GeoUtils.java
+++ b/src/main/java/akuma/whiplash/global/util/GeoUtils.java
@@ -1,0 +1,24 @@
+package akuma.whiplash.global.util;
+
+public class GeoUtils {
+
+    private static final double EARTH_RADIUS_METERS = 6_371_000;
+
+    private GeoUtils() {
+        throw new IllegalArgumentException();
+    }
+
+    public static int calculateDistanceMeters(double latitude1, double longitude1, double latitude2, double longitude2) {
+        double latitudeDistance = Math.toRadians(latitude2 - latitude1);
+        double longitudeDistance = Math.toRadians(longitude2 - longitude1);
+
+        double fromLatitude = Math.toRadians(latitude1);
+        double toLatitude = Math.toRadians(latitude2);
+
+        double haversine = Math.pow(Math.sin(latitudeDistance / 2), 2)
+            + Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.pow(Math.sin(longitudeDistance / 2), 2);
+        double centralAngle = 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+
+        return (int) Math.round(EARTH_RADIUS_METERS * centralAngle);
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/place/application/usecase/PlaceUseCaseTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/application/usecase/PlaceUseCaseTest.java
@@ -1,0 +1,72 @@
+package akuma.whiplash.domains.place.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import akuma.whiplash.domains.place.domain.service.PlaceQueryService;
+import akuma.whiplash.global.exception.ApplicationException;
+import akuma.whiplash.global.response.code.CommonErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceUseCaseTest {
+
+    @Mock private PlaceQueryService placeQueryService;
+    @InjectMocks private PlaceUseCase placeUseCase;
+
+    @Nested
+    @DisplayName("searchPlaces - 장소 목록 검색")
+    class SearchPlacesTest {
+
+        @Test
+        @DisplayName("성공: 검색어와 현재 좌표를 서비스에 전달한다")
+        void success() {
+            // given
+            String query = "카페";
+            Double latitude = 37.0;
+            Double longitude = 127.0;
+
+            // when
+            placeUseCase.searchPlaces(query, latitude, longitude);
+
+            // then
+            verify(placeQueryService).searchPlaces(query, latitude, longitude);
+        }
+
+        @Test
+        @DisplayName("실패: query가 빈 문자열이면 예외가 발생한다")
+        void fail_queryBlank() {
+            // given
+            String query = "";
+
+            // when & then
+            assertThatThrownBy(() -> placeUseCase.searchPlaces(query, null, null))
+                .isInstanceOfSatisfying(ApplicationException.class, e ->
+                    assertThat(e.getCode()).isEqualTo(CommonErrorCode.BAD_REQUEST)
+                );
+            verifyNoInteractions(placeQueryService);
+        }
+
+        @Test
+        @DisplayName("실패: 현재 좌표가 하나만 전달되면 예외가 발생한다")
+        void fail_partialCoordinates() {
+            // given
+            String query = "카페";
+
+            // when & then
+            assertThatThrownBy(() -> placeUseCase.searchPlaces(query, 37.0, null))
+                .isInstanceOfSatisfying(ApplicationException.class, e ->
+                    assertThat(e.getCode()).isEqualTo(CommonErrorCode.BAD_REQUEST)
+                );
+            verifyNoInteractions(placeQueryService);
+        }
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceTest.java
@@ -12,15 +12,13 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-// TODO: 테스트 코드 고치고 이 애노테이션 제거
-@Disabled
 class PlaceQueryServiceTest {
 
     private PlaceQueryServiceImpl placeQueryService;
@@ -31,15 +29,16 @@ class PlaceQueryServiceTest {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
 
-        // ✅ MockWebServer 주소를 baseUrl로 설정하고, 네이버 헤더를 기본 헤더로 세팅
-        WebClient webClient = WebClient.builder()
-            .baseUrl(mockWebServer.url("/").toString()) // e.g. http://127.0.0.1:50543/
-            .defaultHeader("X-Naver-Client-Id", "test-id")
-            .defaultHeader("X-Naver-Client-Secret", "test-secret")
-            .build();
+        WebClient webClient = WebClient.builder().build();
 
-        // ✅ 구현체가 WebClient를 주입받아 상대경로로 호출한다고 가정
         placeQueryService = new PlaceQueryServiceImpl(webClient);
+        ReflectionTestUtils.setField(placeQueryService, "naverClientId", "test-id");
+        ReflectionTestUtils.setField(placeQueryService, "naverClientSecret", "test-secret");
+        ReflectionTestUtils.setField(
+            placeQueryService,
+            "naverLocalSearchUrl",
+            mockWebServer.url("/v1/search/local.json").toString()
+        );
     }
 
     @AfterEach
@@ -54,7 +53,7 @@ class PlaceQueryServiceTest {
         @Test
         @DisplayName("성공: 키워드 검색 결과를 반환한다")
         void success() throws Exception {
-            // given (서비스의 변환 규칙에 맞춘 응답)
+            // given
             String body = """
                 {"items":[
                   {"title":"<b>카페</b>","address":"서울시 강남구 역삼동","roadAddress":"서울시 강남구","mapx":"1270000000","mapy":"370000000"}
@@ -75,7 +74,6 @@ class PlaceQueryServiceTest {
             assertThat(responses.get(0).latitude()).isEqualTo(37.0);
             assertThat(responses.get(0).longitude()).isEqualTo(127.0);
 
-            // ✅ 실제로 MockWebServer가 호출되었는지 검증(외부로 나가지 않음 보장)
             RecordedRequest req = mockWebServer.takeRequest(3, TimeUnit.SECONDS);
             assertThat(req).isNotNull();
             assertThat(req.getPath()).startsWith("/v1/search/local.json");
@@ -89,11 +87,10 @@ class PlaceQueryServiceTest {
             // given
             mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-            // when & then (구현이 retrieve() 기본 onStatus 사용 시 WebClientResponseException 발생)
+            // when & then
             assertThatThrownBy(() -> placeQueryService.searchPlaces("카페", null, null))
                 .isInstanceOf(WebClientResponseException.class);
 
-            // ✅ 요청이 MockWebServer로 갔는지 확인
             RecordedRequest req = mockWebServer.takeRequest(3, TimeUnit.SECONDS);
             assertThat(req).isNotNull();
             assertThat(req.getPath()).startsWith("/v1/search/local.json");

--- a/src/test/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/domain/service/PlaceQueryServiceTest.java
@@ -57,7 +57,7 @@ class PlaceQueryServiceTest {
             // given (서비스의 변환 규칙에 맞춘 응답)
             String body = """
                 {"items":[
-                  {"title":"<b>카페</b>","roadAddress":"서울시 강남구","latitude":37.0,"longitude":127.0}
+                  {"title":"<b>카페</b>","address":"서울시 강남구 역삼동","roadAddress":"서울시 강남구","mapx":"1270000000","mapy":"370000000"}
                 ]}
                 """;
             mockWebServer.enqueue(new MockResponse()
@@ -66,7 +66,7 @@ class PlaceQueryServiceTest {
                 .addHeader("Content-Type", "application/json"));
 
             // when
-            List<PlaceInfoResponse> responses = placeQueryService.searchPlaces("카페");
+            List<PlaceInfoResponse> responses = placeQueryService.searchPlaces("카페", null, null);
 
             // then
             assertThat(responses).hasSize(1);
@@ -90,7 +90,7 @@ class PlaceQueryServiceTest {
             mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
             // when & then (구현이 retrieve() 기본 onStatus 사용 시 WebClientResponseException 발생)
-            assertThatThrownBy(() -> placeQueryService.searchPlaces("카페"))
+            assertThatThrownBy(() -> placeQueryService.searchPlaces("카페", null, null))
                 .isInstanceOf(WebClientResponseException.class);
 
             // ✅ 요청이 MockWebServer로 갔는지 확인

--- a/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerIntegrationTest.java
@@ -1,6 +1,8 @@
 package akuma.whiplash.domains.place.presentation;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import akuma.whiplash.common.config.IntegrationTest;
@@ -8,23 +10,14 @@ import akuma.whiplash.common.fixture.MemberFixture;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-// TODO: 테스트 코드 고치고 이 애노테이션 제거
-@Disabled
 @IntegrationTest
 @AutoConfigureMockMvc
 @DisplayName("PlaceController Integration Test")
@@ -34,28 +27,8 @@ class PlaceControllerIntegrationTest {
     @Autowired private JwtProvider jwtProvider;
     @Autowired private MemberRepository memberRepository;
 
-    private static MockWebServer mockWebServer;
-
-    @BeforeAll
-    static void beforeAll() throws Exception {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-    }
-
-    @AfterAll
-    static void afterAll() throws Exception {
-        mockWebServer.shutdown();
-    }
-
-    @DynamicPropertySource
-    static void registerProps(DynamicPropertyRegistry registry) {
-        // 서비스가 사용하는 base-url 속성 주입
-        registry.add("naver.search.base-url",
-            () -> mockWebServer.url("/").toString());
-    }
-
     @Nested
-    @DisplayName("[GET] /api/places/search - 장소 목록 검색")
+    @DisplayName("[GET] /api/v1/places/search - 장소 목록 검색")
     class SearchPlacesTest {
 
         @Test
@@ -64,15 +37,18 @@ class PlaceControllerIntegrationTest {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_1.toEntity());
             String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
-            String body = "{\"items\":[{\"title\":\"<b>카페</b>\",\"address\":\"서울시 강남구\",\"roadAddress\":\"서울시 강남구\",\"mapx\":\"127000000\",\"mapy\":\"37000000\"}]}";
-            mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).addHeader("Content-Type", "application/json"));
 
-            // when & then
-            mockMvc.perform(get("/api/places/search")
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/search")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                    .param("query", "카페"))
-                .andExpect(status().isOk());
-//                .andExpect(jsonPath("$.result[0].name").value("카페"));
+                    .param("query", "카페"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].name").value("Mock Place 1 for 카페"))
+                .andExpect(jsonPath("$.result[0].address").value("Seoul, Gangnam-gu, Teheran-ro 1"))
+                .andExpect(jsonPath("$.result[0].distanceMeters").value(nullValue()));
         }
 
         @Test
@@ -82,33 +58,127 @@ class PlaceControllerIntegrationTest {
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_2.toEntity());
             String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
 
-            // when & then
-            mockMvc.perform(get("/api/places/search")
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                .andExpect(status().isBadRequest());
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/search")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
         }
 
         @Test
         @DisplayName("실패: 인증 토큰이 없으면 401과 에러 코드를 반환한다")
         void fail_tokenMissing() throws Exception {
-            // when & then
-            mockMvc.perform(get("/api/places/search").param("query", "카페"))
-                .andExpect(status().isUnauthorized());
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/search").param("query", "카페"));
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("[GET] /api/v1/places/detail - 장소 상세 조회")
+    class GetPlaceDetailTest {
+
+        @Test
+        @DisplayName("성공: 좌표로 장소 상세를 조회하면 200과 상세 정보가 반환된다")
+        void success() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_1.toEntity());
+            String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
+
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/detail")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .param("latitude", "37.4979")
+                .param("longitude", "127.0276"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.placeName").value("Mock Detail Place"))
+                .andExpect(jsonPath("$.result.address").value("Seoul, Gangnam-gu, Mock-ro 123"))
+                .andExpect(jsonPath("$.result.roadAddress").value("Seoul, Gangnam-gu, Mock-ro 123"));
         }
 
         @Test
-        @DisplayName("실패: 외부 API가 400을 반환하면 500과 에러 코드를 반환한다")
-        void fail_externalApiError() throws Exception {
+        @DisplayName("실패: 좌표 파라미터가 없으면 400과 에러 코드를 반환한다")
+        void fail_coordinateMissing() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_2.toEntity());
+            String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
+
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/detail")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .param("latitude", "37.4979"));
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 토큰이 없으면 401과 에러 코드를 반환한다")
+        void fail_tokenMissing() throws Exception {
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/detail")
+                .param("latitude", "37.4979")
+                .param("longitude", "127.0276"));
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("[GET] /api/v1/places/keywords - 연관 장소 키워드 추천")
+    class SearchPlaceKeywordsTest {
+
+        @Test
+        @DisplayName("성공: 검색어로 연관 키워드를 조회하면 200과 목록이 반환된다")
+        void success() throws Exception {
             // given
             MemberEntity member = memberRepository.save(MemberFixture.MEMBER_3.toEntity());
             String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
-            mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-            // when & then
-            mockMvc.perform(get("/api/places/search")
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                    .param("query", "카페"))
-                .andExpect(status().isInternalServerError());
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/keywords")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .param("query", "카페"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0]").value("카페 station"))
+                .andExpect(jsonPath("$.result[1]").value("카페 park"))
+                .andExpect(jsonPath("$.result[2]").value("카페 school"));
+        }
+
+        @Test
+        @DisplayName("실패: query 파라미터가 없으면 400과 에러 코드를 반환한다")
+        void fail_queryMissing() throws Exception {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_4.toEntity());
+            String token = jwtProvider.generateAccessToken(member.getId(), member.getRole(), "device");
+
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/keywords")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 토큰이 없으면 401과 에러 코드를 반환한다")
+        void fail_tokenMissing() throws Exception {
+            // when
+            var resultActions = mockMvc.perform(get("/api/v1/places/keywords")
+                .param("query", "카페"));
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import akuma.whiplash.domains.place.application.dto.response.PlaceDetailResponse;
 import akuma.whiplash.domains.place.application.dto.response.PlaceInfoResponse;
 import akuma.whiplash.domains.place.application.usecase.PlaceUseCase;
 import akuma.whiplash.global.config.security.SecurityConfig;
@@ -161,6 +162,123 @@ class PlaceControllerTest {
             var resultActions = mockMvc.perform(get(BASE + "/search")
                 .param("query", "카페")
                 .param("latitude", "37.0"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlaceDetail - 장소 상세 조회")
+    class GetPlaceDetailTest {
+
+        @Test
+        @DisplayName("성공: 200 OK와 장소 상세 정보를 반환한다")
+        void success() throws Exception {
+            // given
+            PlaceDetailResponse response = PlaceDetailResponse.builder()
+                .placeName("강남역")
+                .address("서울특별시 강남구 강남대로 396")
+                .roadAddress("서울특별시 강남구 강남대로 396")
+                .build();
+            when(placeUseCase.getPlaceDetail(eq(37.4979), eq(127.0276))).thenReturn(response);
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/detail")
+                .param("latitude", "37.4979")
+                .param("longitude", "127.0276"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.placeName").value("강남역"))
+                .andExpect(jsonPath("$.result.address").value("서울특별시 강남구 강남대로 396"))
+                .andExpect(jsonPath("$.result.roadAddress").value("서울특별시 강남구 강남대로 396"));
+        }
+
+        @Test
+        @DisplayName("실패: 좌표 파라미터가 없으면 400과 에러 코드를 반환한다")
+        void fail_coordinateMissing() throws Exception {
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/detail")
+                .param("latitude", "37.4979"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 서비스에서 예외가 발생하면 400과 에러 코드를 반환한다")
+        void fail_serviceThrows() throws Exception {
+            // given
+            when(placeUseCase.getPlaceDetail(eq(37.4979), eq(127.0276)))
+                .thenThrow(ApplicationException.from(CommonErrorCode.BAD_REQUEST));
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/detail")
+                .param("latitude", "37.4979")
+                .param("longitude", "127.0276"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("searchPlaceKeywords - 연관 장소 키워드 추천")
+    class SearchPlaceKeywordsTest {
+
+        @Test
+        @DisplayName("성공: 200 OK와 연관 키워드 목록을 반환한다")
+        void success() throws Exception {
+            // given
+            List<String> responses = List.of("포켓몬", "포켓몬카드", "포켓몬 팝업");
+            when(placeUseCase.searchPlaceKeywords(eq("포켓몬"))).thenReturn(responses);
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/keywords")
+                .param("query", "포켓몬"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0]").value("포켓몬"))
+                .andExpect(jsonPath("$.result[1]").value("포켓몬카드"))
+                .andExpect(jsonPath("$.result[2]").value("포켓몬 팝업"));
+        }
+
+        @Test
+        @DisplayName("실패: query 파라미터가 없으면 400과 에러 코드를 반환한다")
+        void fail_queryMissing() throws Exception {
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/keywords"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 서비스에서 예외가 발생하면 400과 에러 코드를 반환한다")
+        void fail_serviceThrows() throws Exception {
+            // given
+            when(placeUseCase.searchPlaceKeywords(eq("포켓몬")))
+                .thenThrow(ApplicationException.from(CommonErrorCode.BAD_REQUEST));
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/keywords")
+                .param("query", "포켓몬"));
 
             // then
             resultActions

--- a/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/akuma/whiplash/domains/place/presentation/PlaceControllerTest.java
@@ -1,8 +1,13 @@
 package akuma.whiplash.domains.place.presentation;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import akuma.whiplash.domains.place.application.dto.response.PlaceInfoResponse;
@@ -39,10 +44,10 @@ class PlaceControllerTest {
     @Autowired private MockMvc mockMvc;
     @MockitoBean private PlaceUseCase placeUseCase;
 
-    private static final String BASE = "/api/places";
+    private static final String BASE = "/api/v1/places";
 
     @Nested
-    @DisplayName("[GET] /api/places/search - 장소 목록 검색")
+    @DisplayName("searchPlaces - 장소 목록 검색")
     class SearchPlacesTest {
 
         @Test
@@ -55,33 +60,113 @@ class PlaceControllerTest {
                     .address("서울시 강남구")
                     .latitude(37.0)
                     .longitude(127.0)
+                    .distanceMeters(120)
                     .build()
             );
-            when(placeUseCase.searchPlaces(anyString())).thenReturn(responses);
+            when(placeUseCase.searchPlaces(eq("카페"), eq(37.0), eq(127.0))).thenReturn(responses);
 
-            // when & then
-            mockMvc.perform(get(BASE + "/search").param("query", "카페"))
-                .andExpect(status().isOk());
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search")
+                .param("query", "카페")
+                .param("latitude", "37.0")
+                .param("longitude", "127.0"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].name").value("카페"))
+                .andExpect(jsonPath("$.result[0].address").value("서울시 강남구"))
+                .andExpect(jsonPath("$.result[0].distanceMeters").value(120));
+        }
+
+        @Test
+        @DisplayName("성공: 현재 좌표가 없으면 distanceMeters null을 반환한다")
+        void success_withoutCoordinates() throws Exception {
+            // given
+            List<PlaceInfoResponse> responses = List.of(
+                PlaceInfoResponse.builder()
+                    .name("카페")
+                    .address("서울시 강남구")
+                    .latitude(37.0)
+                    .longitude(127.0)
+                    .distanceMeters(null)
+                    .build()
+            );
+            when(placeUseCase.searchPlaces(eq("카페"), isNull(), isNull())).thenReturn(responses);
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search").param("query", "카페"));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].distanceMeters").value(nullValue()));
         }
 
         @Test
         @DisplayName("실패: query 파라미터가 없으면 400과 에러 코드를 반환한다")
         void fail_queryMissing() throws Exception {
-            // when & then
-            mockMvc.perform(get(BASE + "/search"))
-                .andExpect(status().isBadRequest());
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: query가 빈 문자열이면 400과 에러 코드를 반환한다")
+        void fail_queryBlank() throws Exception {
+            // given
+            when(placeUseCase.searchPlaces(eq(""), isNull(), isNull()))
+                .thenThrow(ApplicationException.from(CommonErrorCode.BAD_REQUEST));
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search").param("query", ""));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
         }
 
         @Test
         @DisplayName("실패: 서비스에서 예외가 발생하면 400과 에러 코드를 반환한다")
         void fail_serviceThrows() throws Exception {
             // given
-            when(placeUseCase.searchPlaces(anyString()))
+            when(placeUseCase.searchPlaces(anyString(), nullable(Double.class), nullable(Double.class)))
                 .thenThrow(ApplicationException.from(CommonErrorCode.BAD_REQUEST));
 
-            // when & then
-            mockMvc.perform(get(BASE + "/search").param("query", "카페"))
-                .andExpect(status().isBadRequest());
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search").param("query", "카페"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
+        }
+
+        @Test
+        @DisplayName("실패: 현재 좌표가 하나만 전달되면 400과 에러 코드를 반환한다")
+        void fail_partialCoordinates() throws Exception {
+            // given
+            when(placeUseCase.searchPlaces(eq("카페"), eq(37.0), isNull()))
+                .thenThrow(ApplicationException.from(CommonErrorCode.BAD_REQUEST));
+
+            // when
+            var resultActions = mockMvc.perform(get(BASE + "/search")
+                .param("query", "카페")
+                .param("latitude", "37.0"));
+
+            // then
+            resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCustomCode()));
         }
     }
 }

--- a/src/test/java/akuma/whiplash/global/util/GeoUtilsTest.java
+++ b/src/test/java/akuma/whiplash/global/util/GeoUtilsTest.java
@@ -1,0 +1,50 @@
+package akuma.whiplash.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GeoUtilsTest {
+
+    @Nested
+    @DisplayName("calculateDistanceMeters - 좌표 간 거리 계산")
+    class CalculateDistanceMetersTest {
+
+        @Test
+        @DisplayName("성공: 알려진 두 좌표 간 거리를 미터 단위로 계산한다")
+        void success() {
+            // given
+            double seoulStationLatitude = 37.5547;
+            double seoulStationLongitude = 126.9706;
+            double cityHallLatitude = 37.5663;
+            double cityHallLongitude = 126.9779;
+
+            // when
+            int distanceMeters = GeoUtils.calculateDistanceMeters(
+                seoulStationLatitude,
+                seoulStationLongitude,
+                cityHallLatitude,
+                cityHallLongitude
+            );
+
+            // then
+            assertThat(distanceMeters).isBetween(1_400, 1_500);
+        }
+
+        @Test
+        @DisplayName("성공: 동일 좌표는 0m를 반환한다")
+        void success_samePoint() {
+            // given
+            double latitude = 37.5547;
+            double longitude = 126.9706;
+
+            // when
+            int distanceMeters = GeoUtils.calculateDistanceMeters(latitude, longitude, latitude, longitude);
+
+            // then
+            assertThat(distanceMeters).isZero();
+        }
+    }
+}


### PR DESCRIPTION
## 📄 PR 요약
> 장소 검색 API에 거리 응답을 추가하고, 장소 상세 응답 구조와 장소 API 테스트를 개선

## ✍🏻 PR 상세
1. `/api/v1/places/search` 응답에 현재 위치 기준 distanceMeters를 추가
2. 장소 검색 결과에 좌표(latitude, longitude)를 포함해 프론트에서 선택한 장소를 바로 활용할 수 있도록 함
3. `/api/v1/places/detail` 응답 필드를 placeName, address, roadAddress 구조로 변경
4. 외부 API 호출 서비스에서 불필요한 트랜잭션 설정을 제거
5. test 프로필에서 MockPlaceQueryService가 주입되도록 설정해 통합 테스트가 네이버 API에 의존하지 않도록 함
6. 비활성화되어 있던 장소 서비스/컨트롤러 통합 테스트를 활성화하고, /search, /detail, /keywords 테스트 케이스를 보강

👀 참고사항
- 

## ✅ 체크리스트
- [x] PR 양식에 맞게 작성했습니다.
- [x] 모든 테스트가 통과했습니다.
- [x] 프로그램이 정상적으로 작동합니다.
- [x] 적절한 라벨을 설정했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 🚪 연관된 이슈 번호
Closes #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 위치 기반 검색: 선택적 위도/경도 파라미터를 통한 근처 장소 검색 지원
* 검색 결과에 거리(미터) 정보 포함
* 장소 상세 정보의 도로명 주소 추가

## API 변경
* API 기본 경로 업데이트: `/api/v1/places`로 버전 지정

## 개선 사항
* 누락된 요청 파라미터에 대한 오류 처리 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Central-MakeUs/Whiplash-Server/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->