### PR TITLE
Google Maps API 정책에 따라 위/경도 저장 정책을 변경한다.

### DIFF
--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/etc/OccurrencePushInfo.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/etc/OccurrencePushInfo.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 public record OccurrencePushInfo(
     Long occurrenceId,
     Long memberId,
+    Long alarmId,
     String address
 ) {
 

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmRegisterRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/AlarmRegisterRequest.java
@@ -3,6 +3,7 @@ package akuma.whiplash.domains.alarm.application.dto.request;
 import akuma.whiplash.global.util.date.LocalTime24HourDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -16,6 +17,7 @@ public record AlarmRegisterRequest(
 
     @Schema(description = "장소 정보")
     @NotNull(message = "장소 정보를 입력해주세요.")
+    @Valid
     PlaceRequest place,
 
     @Schema(description = "알람 목적", example = "도서관 정기 출석 알람")

--- a/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequest.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "장소 정보 요청 DTO")
 public record PlaceRequest(
@@ -22,6 +23,14 @@ public record PlaceRequest(
     @NotNull(message = "경도를 입력해주세요.")
     @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
     @DecimalMax(value = "180.0", message = "경도는 -180 이하이어야 합니다.")
-    double longitude
-) {
-}
+    double longitude,
+
+    @Schema(description = "Google Places 장소 식별자", example = "ChIJz2v...")
+    @NotBlank(message = "Google Place ID를 입력해주세요.")
+    @Size(max = 255, message = "Google Place ID는 255자 이하여야 합니다.")
+    String googlePlaceId,
+
+    @Schema(description = "장소 자동완성 세션 토큰", nullable = true)
+    @Size(max = 64, message = "장소 세션 토큰은 64자 이하여야 합니다.")
+    String sessionToken
+) {}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/mapper/AlarmMapper.java
@@ -14,6 +14,7 @@ import akuma.whiplash.domains.alarm.domain.constant.AlarmDeleteMethod;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivateType;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.DeleteType;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
@@ -41,7 +42,11 @@ public class AlarmMapper {
         throw new IllegalArgumentException();
     }
 
-    public static AlarmEntity mapToAlarmEntity(AlarmRegisterRequest request, MemberEntity memberEntity) {
+    public static AlarmEntity mapToAlarmEntity(
+        AlarmRegisterRequest request,
+        MemberEntity memberEntity,
+        LocalDateTime locationCachedAt
+    ) {
         return AlarmEntity.builder()
             .member(memberEntity)
             .alarmPurpose(request.alarmPurpose())
@@ -51,6 +56,9 @@ public class AlarmMapper {
             .latitude(request.place().latitude())
             .longitude(request.place().longitude())
             .address(request.place().address())
+            .locationSource(LocationSource.GOOGLE_PLACE)
+            .googlePlaceId(request.place().googlePlaceId())
+            .locationCachedAt(locationCachedAt)
             .status(AlarmStatus.ACTIVE)
             .build();
     }

--- a/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupScheduler.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupScheduler.java
@@ -1,0 +1,62 @@
+package akuma.whiplash.domains.alarm.application.scheduler;
+
+import akuma.whiplash.domains.alarm.domain.service.AlarmLocationCacheCleanupService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlarmLocationCacheCleanupScheduler {
+
+    private final AlarmLocationCacheCleanupService alarmLocationCacheCleanupService;
+    private final MeterRegistry meterRegistry;
+
+    private Counter clearedLocationCacheCounter;
+    private Counter cleanupSuccessCounter;
+    private Counter cleanupFailureCounter;
+    private Timer cleanupTimer;
+    private final AtomicLong lastSuccessEpochSeconds = new AtomicLong();
+
+    @PostConstruct
+    void registerMetrics() {
+        clearedLocationCacheCounter = meterRegistry.counter(
+            "alarm.location_cache.cleared", "source", "google_place"
+        );
+        cleanupSuccessCounter = meterRegistry.counter("alarm.location_cache.cleanup_success");
+        cleanupFailureCounter = meterRegistry.counter("alarm.location_cache.cleanup_failure");
+        cleanupTimer = Timer.builder("alarm.location_cache.cleanup_duration")
+            .description("Google 장소 위치 캐시 정리 작업 실행 시간")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+        Gauge.builder("alarm.location_cache.last_success_epoch_seconds", lastSuccessEpochSeconds, AtomicLong::get)
+            .description("Google 장소 위치 캐시 정리 작업의 마지막 성공 시각")
+            .register(meterRegistry);
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void clearExpiredGoogleLocationCaches() {
+        cleanupTimer.record(() -> {
+            try {
+                int clearedCount = alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches();
+                clearedLocationCacheCounter.increment(clearedCount);
+                cleanupSuccessCounter.increment();
+                lastSuccessEpochSeconds.set(Instant.now().getEpochSecond());
+                log.info("만료된 Google 장소 위치 캐시 {}건을 삭제했습니다.", clearedCount);
+            } catch (RuntimeException exception) {
+                cleanupFailureCounter.increment();
+                log.error("Google 장소 위치 캐시 정리에 실패했습니다.", exception);
+                throw exception;
+            }
+        });
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupScheduler.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupScheduler.java
@@ -44,10 +44,10 @@ public class AlarmLocationCacheCleanupScheduler {
     }
 
     @Scheduled(cron = "0 0 * * * *")
-    public void clearExpiredGoogleLocationCaches() {
+    public void removeExpiredGoogleLocationCaches() {
         cleanupTimer.record(() -> {
             try {
-                int clearedCount = alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches();
+                int clearedCount = alarmLocationCacheCleanupService.removeExpiredGoogleLocationCaches();
                 clearedLocationCacheCounter.increment(clearedCount);
                 cleanupSuccessCounter.increment();
                 lastSuccessEpochSeconds.set(Instant.now().getEpochSecond());

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/constant/LocationSource.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/constant/LocationSource.java
@@ -1,0 +1,7 @@
+package akuma.whiplash.domains.alarm.domain.constant;
+
+public enum LocationSource {
+    USER_PIN,
+    DEVICE_GPS,
+    GOOGLE_PLACE
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
@@ -19,6 +19,7 @@ import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse
 import akuma.whiplash.domains.alarm.application.mapper.AlarmMapper;
 import akuma.whiplash.domains.alarm.application.service.AuditLogRecorder;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.DeactivationResult;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.domain.util.AlarmScheduleCalculator;
@@ -83,6 +84,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     private final AdSessionService adSessionService;
     private final ApplicationEventPublisher eventPublisher;
     private final TimeProvider timeProvider;
+    private final AlarmLocationCacheService alarmLocationCacheService;
 
     private static final double CHECKIN_RADIUS_METERS = 50.0;
 
@@ -96,7 +98,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         }
 
         // 1. 알람 엔티티 생성 및 저장
-        AlarmEntity alarm = AlarmMapper.mapToAlarmEntity(request, memberEntity);
+        AlarmEntity alarm = AlarmMapper.mapToAlarmEntity(request, memberEntity, timeProvider.now());
         alarmRepository.save(alarm);
 
         // 2. 다음 알람 발생 날짜 계산
@@ -293,7 +295,16 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             throw ApplicationException.from(CHECKIN_NOT_YET_AVAILABLE);
         }
 
-        // 4. 사용자가 알람 목적지 반경 50m 안에 있는지 검증한다.
+        // 4. Google 장소 캐시가 만료됐으면 Place ID로 갱신한 좌표만 사용한다.
+        if (alarm.getLocationSource() == LocationSource.GOOGLE_PLACE
+            && !alarmLocationCacheService.hasValidGoogleLocationCache(alarm, processedAt)) {
+            if (!alarm.hasGooglePlaceId()) {
+                throw ApplicationException.from(ALARM_LOCATION_RESELECTION_REQUIRED);
+            }
+            alarmLocationCacheService.refreshGoogleLocationCache(alarm);
+        }
+
+        // 5. 사용자가 알람 목적지 반경 50m 안에 있는지 검증한다.
         boolean isInRange = isWithinDistance(
             alarm.getLatitude(), alarm.getLongitude(),
             request.latitude(), request.longitude(), CHECKIN_RADIUS_METERS);
@@ -302,17 +313,17 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             throw ApplicationException.from(CHECKIN_OUT_OF_RANGE);
         }
 
-        // 5. 체크인 완료 시각을 기록하고 회차 상태를 CHECKIN으로 전환한다.
+        // 6. 체크인 완료 시각을 기록하고 회차 상태를 CHECKIN으로 전환한다.
         occurrence.checkin(processedAt);
 
-        // 6. 클라이언트 동기화를 위해 다음 예정 회차를 함께 조회한다.
+        // 7. 클라이언트 동기화를 위해 다음 예정 회차를 함께 조회한다.
         AlarmOccurrenceEntity nextOccurrence = alarmOccurrenceRepository
             .findNextScheduledByAlarmIds(List.of(alarmId), OccurrenceStatus.SCHEDULED, processedAt)
             .stream()
             .findFirst()
             .orElse(null);
 
-        // 7. 체크인 로그는 본 처리와 분리해 커밋 후 별도 트랜잭션에서 best-effort로 저장한다.
+        // 8. 체크인 로그는 본 처리와 분리해 커밋 후 별도 트랜잭션에서 best-effort로 저장한다.
         eventPublisher.publishEvent(new AlarmCheckinCompletedEvent(
             occurrence.getId(),
             member.getId(),
@@ -321,7 +332,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             processedAt
         ));
 
-        // 8. 다음 회차 정보를 포함한 응답을 반환한다.
+        // 9. 다음 회차 정보를 포함한 응답을 반환한다.
         return AlarmMapper.mapToAlarmCheckinResponse(alarm, nextOccurrence);
     }
 

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceImpl.java
@@ -301,7 +301,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
             if (!alarm.hasGooglePlaceId()) {
                 throw ApplicationException.from(ALARM_LOCATION_RESELECTION_REQUIRED);
             }
-            alarmLocationCacheService.refreshGoogleLocationCache(alarm);
+            alarmLocationCacheService.modifyGoogleLocationCache(alarm);
         }
 
         // 5. 사용자가 알람 목적지 반경 50m 안에 있는지 검증한다.

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupService.java
@@ -1,0 +1,28 @@
+package akuma.whiplash.domains.alarm.domain.service;
+
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.global.util.date.TimeProvider;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmLocationCacheCleanupService {
+
+    private static final int CACHE_VALID_DAYS = 29;
+
+    private final AlarmRepository alarmRepository;
+    private final TimeProvider timeProvider;
+
+    @Transactional
+    public int clearExpiredGoogleLocationCaches() {
+        LocalDateTime expiresAt = timeProvider.now().minusDays(CACHE_VALID_DAYS);
+        return alarmRepository.clearLocationCachesBySourceAndCachedAtBefore(
+            LocationSource.GOOGLE_PLACE,
+            expiresAt
+        );
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupService.java
@@ -18,9 +18,9 @@ public class AlarmLocationCacheCleanupService {
     private final TimeProvider timeProvider;
 
     @Transactional
-    public int clearExpiredGoogleLocationCaches() {
+    public int removeExpiredGoogleLocationCaches() {
         LocalDateTime expiresAt = timeProvider.now().minusDays(CACHE_VALID_DAYS);
-        return alarmRepository.clearLocationCachesBySourceAndCachedAtBefore(
+        return alarmRepository.updateLocationCachesBySourceAndCachedAtBefore(
             LocationSource.GOOGLE_PLACE,
             expiresAt
         );

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCachePersistenceService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCachePersistenceService.java
@@ -1,0 +1,45 @@
+package akuma.whiplash.domains.alarm.domain.service;
+
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.domains.place.domain.model.SelectedPlaceDetail;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmLocationCachePersistenceService {
+
+    private final AlarmRepository alarmRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void modifyGoogleLocationCache(
+        Long alarmId,
+        SelectedPlaceDetail detail,
+        LocalDateTime locationCachedAt
+    ) {
+        alarmRepository.findById(alarmId).ifPresent(alarm -> updateGoogleLocationCache(alarm, detail, locationCachedAt));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void removeGoogleLocationCache(Long alarmId) {
+        alarmRepository.findById(alarmId).ifPresent(AlarmEntity::clearGooglePlaceLocationCache);
+    }
+
+    private void updateGoogleLocationCache(
+        AlarmEntity alarm,
+        SelectedPlaceDetail detail,
+        LocalDateTime locationCachedAt
+    ) {
+        alarm.updateGooglePlaceLocation(
+            detail.providerPlaceId(),
+            detail.address(),
+            detail.latitude(),
+            detail.longitude(),
+            locationCachedAt
+        );
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheService.java
@@ -22,6 +22,7 @@ public class AlarmLocationCacheService {
 
     private final GoogleClient googleClient;
     private final TimeProvider timeProvider;
+    private final AlarmLocationCachePersistenceService alarmLocationCachePersistenceService;
 
     public boolean hasValidGoogleLocationCache(AlarmEntity alarm, LocalDateTime now) {
         return alarm.getLocationSource() == LocationSource.GOOGLE_PLACE
@@ -36,21 +37,29 @@ public class AlarmLocationCacheService {
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public void refreshGoogleLocationCache(AlarmEntity alarm) {
-        refreshGoogleLocationCache(alarm, null);
+    public void modifyGoogleLocationCache(AlarmEntity alarm) {
+        modifyGoogleLocationCache(alarm, null);
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public void refreshGoogleLocationCache(AlarmEntity alarm, String sessionToken) {
-        SelectedPlaceDetail detail = googleClient.getPlaceDetails(
-            new PlaceDetailsCriteria(alarm.getGooglePlaceId(), sessionToken, null, null)
-        );
-        alarm.updateGooglePlaceLocation(
-            detail.providerPlaceId(),
-            detail.address(),
-            detail.latitude(),
-            detail.longitude(),
-            timeProvider.now()
-        );
+    public void modifyGoogleLocationCache(AlarmEntity alarm, String sessionToken) {
+        try {
+            SelectedPlaceDetail detail = googleClient.getPlaceDetails(
+                new PlaceDetailsCriteria(alarm.getGooglePlaceId(), sessionToken, null, null)
+            );
+            LocalDateTime locationCachedAt = timeProvider.now();
+            alarm.updateGooglePlaceLocation(
+                detail.providerPlaceId(),
+                detail.address(),
+                detail.latitude(),
+                detail.longitude(),
+                locationCachedAt
+            );
+            alarmLocationCachePersistenceService.modifyGoogleLocationCache(alarm.getId(), detail, locationCachedAt);
+        } catch (RuntimeException exception) {
+            alarm.clearGooglePlaceLocationCache();
+            alarmLocationCachePersistenceService.removeGoogleLocationCache(alarm.getId());
+            throw exception;
+        }
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheService.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheService.java
@@ -1,0 +1,56 @@
+package akuma.whiplash.domains.alarm.domain.service;
+
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.place.domain.client.GoogleClient;
+import akuma.whiplash.domains.place.domain.model.PlaceDetailsCriteria;
+import akuma.whiplash.domains.place.domain.model.SelectedPlaceDetail;
+import akuma.whiplash.global.log.NoMethodLog;
+import akuma.whiplash.global.util.date.TimeProvider;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@NoMethodLog
+public class AlarmLocationCacheService {
+
+    private static final int CACHE_VALID_DAYS = 29;
+
+    private final GoogleClient googleClient;
+    private final TimeProvider timeProvider;
+
+    public boolean hasValidGoogleLocationCache(AlarmEntity alarm, LocalDateTime now) {
+        return alarm.getLocationSource() == LocationSource.GOOGLE_PLACE
+            && alarm.getLatitude() != null
+            && alarm.getLongitude() != null
+            && alarm.getLocationCachedAt() != null
+            && alarm.getLocationCachedAt().plusDays(CACHE_VALID_DAYS).isAfter(now);
+    }
+
+    public boolean canRefreshGoogleLocationCache(AlarmEntity alarm) {
+        return alarm.getLocationSource() == LocationSource.GOOGLE_PLACE && alarm.hasGooglePlaceId();
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void refreshGoogleLocationCache(AlarmEntity alarm) {
+        refreshGoogleLocationCache(alarm, null);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void refreshGoogleLocationCache(AlarmEntity alarm, String sessionToken) {
+        SelectedPlaceDetail detail = googleClient.getPlaceDetails(
+            new PlaceDetailsCriteria(alarm.getGooglePlaceId(), sessionToken, null, null)
+        );
+        alarm.updateGooglePlaceLocation(
+            detail.providerPlaceId(),
+            detail.address(),
+            detail.latitude(),
+            detail.longitude(),
+            timeProvider.now()
+        );
+    }
+}

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
@@ -58,6 +58,7 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     private final MemberRepository memberRepository;
     private final MemberDeviceRepository memberDeviceRepository;
     private final TimeProvider timeProvider;
+    private final AlarmLocationCacheService alarmLocationCacheService;
 
     @Override
     public GetAlarmsResponse getAlarms(Long memberId, String deviceId) {
@@ -66,6 +67,8 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
 
         ZoneId memberZone = resolveMemberZone(memberId, deviceId);
         List<AlarmEntity> alarms = alarmRepository.findAllByMemberIdAndStatusNot(memberId, AlarmStatus.DELETED);
+
+        refreshMissingGooglePlaceAddresses(alarms);
 
         if (alarms.isEmpty()) {
             return GetAlarmsResponse.builder()
@@ -229,5 +232,12 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
             .map(MemberDeviceEntity::getTimeZone)
             .map(AlarmScheduleCalculator::resolveZone)
             .orElse(AlarmScheduleCalculator.DEFAULT_ZONE);
+    }
+
+    private void refreshMissingGooglePlaceAddresses(List<AlarmEntity> alarms) {
+        alarms.stream()
+            .filter(alarm -> alarm.getAddress() == null)
+            .filter(alarmLocationCacheService::canRefreshGoogleLocationCache)
+            .forEach(alarmLocationCacheService::refreshGoogleLocationCache);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
@@ -29,6 +29,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +59,7 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     private final MemberRepository memberRepository;
     private final MemberDeviceRepository memberDeviceRepository;
     private final TimeProvider timeProvider;
+    private final AlarmLocationCacheService alarmLocationCacheService;
 
     @Override
     public GetAlarmsResponse getAlarms(Long memberId, String deviceId) {
@@ -66,6 +68,8 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
 
         ZoneId memberZone = resolveMemberZone(memberId, deviceId);
         List<AlarmEntity> alarms = alarmRepository.findAllByMemberIdAndStatusNot(memberId, AlarmStatus.DELETED);
+
+        refreshMissingGooglePlaceAddresses(alarms);
 
         if (alarms.isEmpty()) {
             return GetAlarmsResponse.builder()
@@ -196,12 +200,31 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
     }
 
     @Override
+    @Transactional
     public List<OccurrencePushInfo> getPreNotificationTargets(LocalDateTime startInclusive, LocalDateTime endInclusive) {
-        return alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
+        List<OccurrencePushInfo> infos = alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
             startInclusive,
             endInclusive,
             OccurrenceStatus.SCHEDULED
         );
+        if (infos.isEmpty()) {
+            return infos;
+        }
+
+        Map<Long, AlarmEntity> alarmsById = alarmRepository.findAllById(
+                infos.stream().map(OccurrencePushInfo::alarmId).distinct().toList()
+            ).stream()
+            .collect(Collectors.toMap(AlarmEntity::getId, alarm -> alarm));
+
+        refreshMissingGooglePlaceAddresses(new ArrayList<>(alarmsById.values()));
+
+        return infos.stream()
+            .map(info -> {
+                AlarmEntity alarm = alarmsById.get(info.alarmId());
+                String address = alarm == null ? info.address() : alarm.getAddress();
+                return new OccurrencePushInfo(info.occurrenceId(), info.memberId(), info.alarmId(), address);
+            })
+            .toList();
     }
 
     @Override
@@ -229,5 +252,12 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
             .map(MemberDeviceEntity::getTimeZone)
             .map(AlarmScheduleCalculator::resolveZone)
             .orElse(AlarmScheduleCalculator.DEFAULT_ZONE);
+    }
+
+    private void refreshMissingGooglePlaceAddresses(List<AlarmEntity> alarms) {
+        alarms.stream()
+            .filter(alarm -> alarm.getAddress() == null)
+            .filter(alarmLocationCacheService::canRefreshGoogleLocationCache)
+            .forEach(alarmLocationCacheService::refreshGoogleLocationCache);
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceImpl.java
@@ -256,8 +256,14 @@ public class AlarmQueryServiceImpl implements AlarmQueryService {
 
     private void refreshMissingGooglePlaceAddresses(List<AlarmEntity> alarms) {
         alarms.stream()
-            .filter(alarm -> alarm.getAddress() == null)
+            .filter(alarm -> !alarmLocationCacheService.hasValidGoogleLocationCache(alarm, timeProvider.now()))
             .filter(alarmLocationCacheService::canRefreshGoogleLocationCache)
-            .forEach(alarmLocationCacheService::refreshGoogleLocationCache);
+            .forEach(alarm -> {
+                try {
+                    alarmLocationCacheService.modifyGoogleLocationCache(alarm);
+                } catch (RuntimeException exception) {
+                    log.warn("Google 장소 캐시 갱신에 실패했습니다. alarmId={}", alarm.getId(), exception);
+                }
+            });
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
@@ -19,7 +19,7 @@ public enum AlarmErrorCode implements BaseErrorCode {
     NOT_ALARM_TIME(HttpStatus.BAD_REQUEST, "ALARM_011", "알람이 울릴 시간이 아닙니다."),
     DUPLICATE_ALARM_PURPOSE(HttpStatus.CONFLICT, "ALARM_012", "같은 이름의 알람이 존재합니다!"),
     CHECKIN_NOT_YET_AVAILABLE(HttpStatus.BAD_REQUEST, "ALARM_013", "아직 위치 인증이 가능한 시간이 아닙니다."),
-    ALARM_LOCATION_RESELECTION_REQUIRED(HttpStatus.BAD_REQUEST, "ALARM_014", "알람 장소를 다시 선택해주세요."),
+    ALARM_LOCATION_RESELECTION_REQUIRED(HttpStatus.BAD_REQUEST, "ALARM_014", "알람 장소 재선택이 필요합니다."),
 
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM_401", "존재하지 않는 알람입니다."),
     ALARM_OCCURRENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM_402", "알람 발생 내역이 존재하지 않습니다.")

--- a/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/exception/AlarmErrorCode.java
@@ -19,6 +19,7 @@ public enum AlarmErrorCode implements BaseErrorCode {
     NOT_ALARM_TIME(HttpStatus.BAD_REQUEST, "ALARM_011", "알람이 울릴 시간이 아닙니다."),
     DUPLICATE_ALARM_PURPOSE(HttpStatus.CONFLICT, "ALARM_012", "같은 이름의 알람이 존재합니다!"),
     CHECKIN_NOT_YET_AVAILABLE(HttpStatus.BAD_REQUEST, "ALARM_013", "아직 위치 인증이 가능한 시간이 아닙니다."),
+    ALARM_LOCATION_RESELECTION_REQUIRED(HttpStatus.BAD_REQUEST, "ALARM_014", "알람 장소를 다시 선택해주세요."),
 
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM_401", "존재하지 않는 알람입니다."),
     ALARM_OCCURRENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM_402", "알람 발생 내역이 존재하지 않습니다.")

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmEntity.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/entity/AlarmEntity.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.domains.alarm.persistence.entity;
 
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.domain.util.RepeatDaysConverter;
@@ -61,14 +62,25 @@ public class AlarmEntity extends BaseTimeEntity {
     @Column(name = "sound_type", length = 20, nullable = false)
     private SoundType soundType = SoundType.VIBRATION_ONLY;
 
-    @Column(nullable = false)
+    @Column
     private Double latitude;
 
-    @Column(nullable = false)
+    @Column
     private Double longitude;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 255)
     private String address;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "location_source", length = 20, nullable = false)
+    private LocationSource locationSource = LocationSource.GOOGLE_PLACE;
+
+    @Column(name = "google_place_id", length = 255)
+    private String googlePlaceId;
+
+    @Column(name = "location_cached_at")
+    private LocalDateTime locationCachedAt;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
@@ -88,5 +100,34 @@ public class AlarmEntity extends BaseTimeEntity {
     public void softDelete(LocalDateTime now) {
         this.status = AlarmStatus.DELETED;
         this.deletedAt = now;
+    }
+
+    public void updateGooglePlaceLocation(
+        String googlePlaceId,
+        String address,
+        double latitude,
+        double longitude,
+        LocalDateTime locationCachedAt
+    ) {
+        this.locationSource = LocationSource.GOOGLE_PLACE;
+        this.googlePlaceId = googlePlaceId;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.locationCachedAt = locationCachedAt;
+    }
+
+    public void clearGooglePlaceLocationCache() {
+        if (locationSource != LocationSource.GOOGLE_PLACE) {
+            return;
+        }
+        this.latitude = null;
+        this.longitude = null;
+        this.address = null;
+        this.locationCachedAt = null;
+    }
+
+    public boolean hasGooglePlaceId() {
+        return googlePlaceId != null && !googlePlaceId.isBlank();
     }
 }

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmOccurrenceRepository.java
@@ -90,7 +90,7 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     void deleteByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
-    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.address)
+    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.id, a.address)
     FROM AlarmOccurrenceEntity o
     JOIN o.alarm a
     JOIN a.member m
@@ -107,7 +107,7 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     );
 
     @Query("""
-    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.address)
+    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.id, a.address)
     FROM AlarmOccurrenceEntity o
     JOIN o.alarm a
     JOIN a.member m
@@ -123,7 +123,7 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     );
 
     @Query("""
-    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.address)
+    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.id, a.address)
     FROM AlarmOccurrenceEntity o
     JOIN o.alarm a
     JOIN a.member m
@@ -139,7 +139,7 @@ public interface AlarmOccurrenceRepository extends JpaRepository<AlarmOccurrence
     );
 
     @Query("""
-    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.address)
+    SELECT new akuma.whiplash.domains.alarm.application.dto.etc.OccurrencePushInfo(o.id, m.id, a.id, a.address)
     FROM AlarmOccurrenceEntity o
     JOIN o.alarm a
     JOIN a.member m

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
@@ -77,7 +77,7 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, Long> {
         WHERE a.locationSource = :locationSource
           AND a.locationCachedAt <= :expiresAt
     """)
-    int clearLocationCachesBySourceAndCachedAtBefore(
+    int updateLocationCachesBySourceAndCachedAtBefore(
         @Param("locationSource") LocationSource locationSource,
         @Param("expiresAt") LocalDateTime expiresAt
     );

--- a/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepository.java
@@ -1,7 +1,9 @@
 package akuma.whiplash.domains.alarm.persistence.repository;
 
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -64,6 +66,21 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, Long> {
         WHERE a.member.id = :memberId
     """)
     void deleteByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("""
+        UPDATE AlarmEntity a
+        SET a.latitude = NULL,
+            a.longitude = NULL,
+            a.address = NULL,
+            a.locationCachedAt = NULL
+        WHERE a.locationSource = :locationSource
+          AND a.locationCachedAt <= :expiresAt
+    """)
+    int clearLocationCachesBySourceAndCachedAtBefore(
+        @Param("locationSource") LocationSource locationSource,
+        @Param("expiresAt") LocalDateTime expiresAt
+    );
 
     interface AlarmOccurrenceBatchTarget {
         Long getAlarmId();

--- a/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
+++ b/src/main/java/akuma/whiplash/domains/alarm/presentation/AlarmController.java
@@ -151,7 +151,8 @@ public class AlarmController {
             ALARM_OCCURRENCE_NOT_FOUND,
             CHECKIN_OUT_OF_RANGE,
             ALREADY_DEACTIVATED,
-            CHECKIN_NOT_YET_AVAILABLE
+            CHECKIN_NOT_YET_AVAILABLE,
+            ALARM_LOCATION_RESELECTION_REQUIRED
         },
         authErrorCodes = {PERMISSION_DENIED}
     )

--- a/src/main/java/akuma/whiplash/domains/place/domain/client/impl/GoogleClientImpl.java
+++ b/src/main/java/akuma/whiplash/domains/place/domain/client/impl/GoogleClientImpl.java
@@ -175,8 +175,10 @@ public class GoogleClientImpl implements GoogleClient {
 
     private GooglePlaceDetailsResponse requestPlaceDetails(PlaceDetailsCriteria criteria) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(placeDetailsUrl)
-            .pathSegment(criteria.providerPlaceId())
-            .queryParam("sessionToken", criteria.sessionToken());
+            .pathSegment(criteria.providerPlaceId());
+        if (criteria.sessionToken() != null && !criteria.sessionToken().isBlank()) {
+            uriBuilder.queryParam("sessionToken", criteria.sessionToken());
+        }
         if (criteria.languageCode() != null) {
             uriBuilder.queryParam("languageCode", criteria.languageCode());
         }

--- a/src/main/java/akuma/whiplash/global/log/LogUtils.java
+++ b/src/main/java/akuma/whiplash/global/log/LogUtils.java
@@ -18,9 +18,9 @@ public final class LogUtils {
 
     private static final Set<String> SENSITIVE_KEYS = Set.of(
         "password", "passwd", "pwd", "authorization", "accesstoken", "refreshtoken",
-        "token", "secret", "apikey", "privatekey", "email", "phone", "ssn", "address",
+        "token", "sessiontoken", "secret", "apikey", "privatekey", "email", "phone", "ssn", "address",
         "deviceid", "clientid", "sessionid", "fcmtoken", "paymentid", "adprooftoken",
-        "latitude", "longitude"
+        "latitude", "longitude", "googleplaceid", "placeid", "place_id"
     );
 
     public static String nowIso() {

--- a/src/main/java/akuma/whiplash/global/log/LogUtils.java
+++ b/src/main/java/akuma/whiplash/global/log/LogUtils.java
@@ -18,9 +18,9 @@ public final class LogUtils {
 
     private static final Set<String> SENSITIVE_KEYS = Set.of(
         "password", "passwd", "pwd", "authorization", "accesstoken", "refreshtoken",
-        "token", "sessiontoken", "secret", "apikey", "privatekey", "email", "phone", "ssn", "address",
+        "token", "sessiontoken", "session_token", "secret", "apikey", "privatekey", "email", "phone", "ssn", "address",
         "deviceid", "clientid", "sessionid", "fcmtoken", "paymentid", "adprooftoken",
-        "latitude", "longitude", "googleplaceid", "placeid", "place_id"
+        "latitude", "longitude", "googleplaceid", "google_place_id", "placeid", "place_id"
     );
 
     public static String nowIso() {

--- a/src/main/java/akuma/whiplash/global/service/ProdArchiveService.java
+++ b/src/main/java/akuma/whiplash/global/service/ProdArchiveService.java
@@ -41,7 +41,10 @@ public class ProdArchiveService implements ArchiveService {
             latitude, longitude, address, created_at, updated_at
         )
         SELECT a.id, a.member_id, a.alarm_purpose, a.time, a.repeat_days, a.sound_type,
-               a.latitude, a.longitude, a.address, a.created_at, a.updated_at
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.latitude END,
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.longitude END,
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.address END,
+               a.created_at, a.updated_at
         FROM alarm a
         WHERE a.id = ?
           AND NOT EXISTS (
@@ -56,7 +59,10 @@ public class ProdArchiveService implements ArchiveService {
             latitude, longitude, address, created_at, updated_at
         )
         SELECT a.id, a.member_id, a.alarm_purpose, a.time, a.repeat_days, a.sound_type,
-               a.latitude, a.longitude, a.address, a.created_at, a.updated_at
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.latitude END,
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.longitude END,
+               CASE WHEN a.location_source = 'GOOGLE_PLACE' THEN NULL ELSE a.address END,
+               a.created_at, a.updated_at
         FROM alarm a
         WHERE a.member_id = ?
           AND NOT EXISTS (

--- a/src/main/java/akuma/whiplash/infrastructure/firebase/FcmService.java
+++ b/src/main/java/akuma/whiplash/infrastructure/firebase/FcmService.java
@@ -38,6 +38,7 @@ public class FcmService {
     private static final int FCM_MULTICAST_LIMIT = 500;
     private static final String DEFAULT_TITLE = "눈 떠";
     private static final String RINGING_BODY = "알람이 울리고 있어요! 앱으로 접속해서 알람을 꺼주세요!";
+    private static final String PRE_ALARM_BODY_WITHOUT_ADDRESS = "1시간 뒤 알람이 울릴 예정이에요!";
     
     // TODO: 테스트용 지연 변수 (배포 시 제거 필요)
     public static long TEST_DELAY_MS = 0;
@@ -71,9 +72,7 @@ public class FcmService {
 
         // body 문구가 동일한 것끼리 묶어서 멀티캐스트 효율 증가
         Map<String, List<PushTargetDto>> groupedByBody = targets.stream()
-            .collect(Collectors.groupingBy(
-                dto -> String.format("1시간 뒤 %s에서 알림이 울릴 예정이에요!", dto.address())
-            ));
+            .collect(Collectors.groupingBy(dto -> getPreAlarmBody(dto.address())));
 
         Set<Long> successOccurrenceIds = new HashSet<>();
         List<String> invalidTokens = new ArrayList<>();
@@ -131,6 +130,12 @@ public class FcmService {
             .successCount(totalSuccessCount)
             .failedCount(totalFailureCount)
             .build();
+    }
+
+    static String getPreAlarmBody(String address) {
+        return address == null
+            ? PRE_ALARM_BODY_WITHOUT_ADDRESS
+            : String.format("1시간 뒤 %s에서 알림이 울릴 예정이에요!", address);
     }
 
     /**

--- a/src/main/resources/db/migration/V014__add_google_place_location_cache.sql
+++ b/src/main/resources/db/migration/V014__add_google_place_location_cache.sql
@@ -1,0 +1,15 @@
+ALTER TABLE alarm
+    MODIFY COLUMN latitude DOUBLE NULL COMMENT '목표 위치 위도 | Google 장소는 임시 캐시',
+    MODIFY COLUMN longitude DOUBLE NULL COMMENT '목표 위치 경도 | Google 장소는 임시 캐시',
+    MODIFY COLUMN address VARCHAR(255) NULL COMMENT '목표 위치 주소 | Google 장소는 임시 캐시',
+    ADD COLUMN location_source VARCHAR(20) NOT NULL DEFAULT 'GOOGLE_PLACE' COMMENT '위치 데이터 출처',
+    ADD COLUMN google_place_id VARCHAR(255) NULL COMMENT 'Google Place ID',
+    ADD COLUMN location_cached_at DATETIME(6) NULL COMMENT 'Google 위치 캐시 저장 시각',
+    ADD KEY idx_alarm_location_cache_cleanup (location_source, location_cached_at);
+
+UPDATE alarm
+SET location_source = 'GOOGLE_PLACE',
+    latitude = NULL,
+    longitude = NULL,
+    address = NULL,
+    location_cached_at = NULL;

--- a/src/test/java/akuma/whiplash/common/fixture/AlarmFixture.java
+++ b/src/test/java/akuma/whiplash/common/fixture/AlarmFixture.java
@@ -1,6 +1,7 @@
 package akuma.whiplash.common.fixture;
 
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
@@ -75,6 +76,7 @@ public enum AlarmFixture {
             .latitude(latitude)
             .longitude(longitude)
             .address(address)
+            .locationSource(LocationSource.USER_PIN)
             .member(member.toEntity())
             .build();
     }
@@ -89,6 +91,7 @@ public enum AlarmFixture {
             .latitude(latitude)
             .longitude(longitude)
             .address(address)
+            .locationSource(LocationSource.USER_PIN)
             .member(member)
             .build();
     }
@@ -102,6 +105,7 @@ public enum AlarmFixture {
             .latitude(latitude)
             .longitude(longitude)
             .address(address)
+            .locationSource(LocationSource.USER_PIN)
             .member(member)
             .build();
     }

--- a/src/test/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequestTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequestTest.java
@@ -4,17 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("PlaceRequest Unit Test")
+@DisplayName("알람 장소 요청을 검증한다")
 class PlaceRequestTest {
 
     private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
     @Nested
-    @DisplayName("googlePlaceId - Google 장소 식별자")
+    @DisplayName("Google Place ID를 검증한다")
     class GooglePlaceIdTest {
 
         @Test
@@ -31,5 +33,26 @@ class PlaceRequestTest {
                 .extracting(violation -> violation.getPropertyPath().toString())
                 .contains("googlePlaceId");
         }
+    }
+
+    @Test
+    @DisplayName("실패: 알람 등록 요청은 중첩된 Google Place ID를 검증한다")
+    void fail_alarmRegisterRequestWithBlankGooglePlaceId() {
+        // given
+        AlarmRegisterRequest request = new AlarmRegisterRequest(
+            new PlaceRequest("서울시 중구 퇴계로 24", 37.564213, 127.001698, "", null),
+            "출근",
+            LocalTime.of(8, 0),
+            List.of("MONDAY"),
+            "KARINA_SCOLDING"
+        );
+
+        // when
+        var violations = validator.validate(request);
+
+        // then
+        assertThat(violations)
+            .extracting(violation -> violation.getPropertyPath().toString())
+            .contains("place.googlePlaceId");
     }
 }

--- a/src/test/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequestTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/application/dto/request/PlaceRequestTest.java
@@ -1,0 +1,35 @@
+package akuma.whiplash.domains.alarm.application.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PlaceRequest Unit Test")
+class PlaceRequestTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Nested
+    @DisplayName("googlePlaceId - Google 장소 식별자")
+    class GooglePlaceIdTest {
+
+        @Test
+        @DisplayName("실패: Google Place ID 없이 알람 장소를 등록할 수 없다")
+        void fail_googlePlaceIdMissing() {
+            // given
+            PlaceRequest request = new PlaceRequest("서울시 중구 퇴계로 24", 37.564213, 127.001698, "", null);
+
+            // when
+            var violations = validator.validate(request);
+
+            // then
+            assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("googlePlaceId");
+        }
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupSchedulerTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupSchedulerTest.java
@@ -1,0 +1,66 @@
+package akuma.whiplash.domains.alarm.application.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import akuma.whiplash.domains.alarm.domain.service.AlarmLocationCacheCleanupService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlarmLocationCacheCleanupScheduler Unit Test")
+class AlarmLocationCacheCleanupSchedulerTest {
+
+    @Mock
+    private AlarmLocationCacheCleanupService alarmLocationCacheCleanupService;
+
+    private SimpleMeterRegistry meterRegistry;
+    private AlarmLocationCacheCleanupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        scheduler = new AlarmLocationCacheCleanupScheduler(alarmLocationCacheCleanupService, meterRegistry);
+        scheduler.registerMetrics();
+    }
+
+    @Nested
+    @DisplayName("clearExpiredGoogleLocationCaches - 만료 캐시 정리")
+    class ClearExpiredGoogleLocationCachesTest {
+
+        @Test
+        @DisplayName("성공: 삭제 건수와 마지막 성공 시각을 기록한다")
+        void success() {
+            // given
+            given(alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches()).willReturn(3);
+
+            // when
+            scheduler.clearExpiredGoogleLocationCaches();
+
+            // then
+            assertThat(meterRegistry.get("alarm.location_cache.cleared").counter().count()).isEqualTo(3);
+            assertThat(meterRegistry.get("alarm.location_cache.last_success_epoch_seconds").gauge().value()).isPositive();
+        }
+
+        @Test
+        @DisplayName("성공: 정리 실패를 실패 지표로 기록하고 예외를 다시 던진다")
+        void success_recordsFailureMetric() {
+            // given
+            given(alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches())
+                .willThrow(new IllegalStateException("database unavailable"));
+
+            // when
+            org.assertj.core.api.Assertions.assertThatThrownBy(scheduler::clearExpiredGoogleLocationCaches)
+                .isInstanceOf(IllegalStateException.class);
+
+            // then
+            assertThat(meterRegistry.get("alarm.location_cache.cleanup_failure").counter().count()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupSchedulerTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/application/scheduler/AlarmLocationCacheCleanupSchedulerTest.java
@@ -31,17 +31,17 @@ class AlarmLocationCacheCleanupSchedulerTest {
     }
 
     @Nested
-    @DisplayName("clearExpiredGoogleLocationCaches - 만료 캐시 정리")
-    class ClearExpiredGoogleLocationCachesTest {
+    @DisplayName("만료된 Google 장소 위치 캐시를 정리한다")
+    class RemoveExpiredGoogleLocationCachesTest {
 
         @Test
         @DisplayName("성공: 삭제 건수와 마지막 성공 시각을 기록한다")
         void success() {
             // given
-            given(alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches()).willReturn(3);
+            given(alarmLocationCacheCleanupService.removeExpiredGoogleLocationCaches()).willReturn(3);
 
             // when
-            scheduler.clearExpiredGoogleLocationCaches();
+            scheduler.removeExpiredGoogleLocationCaches();
 
             // then
             assertThat(meterRegistry.get("alarm.location_cache.cleared").counter().count()).isEqualTo(3);
@@ -49,14 +49,14 @@ class AlarmLocationCacheCleanupSchedulerTest {
         }
 
         @Test
-        @DisplayName("성공: 정리 실패를 실패 지표로 기록하고 예외를 다시 던진다")
-        void success_recordsFailureMetric() {
+        @DisplayName("실패: 정리 실패를 실패 지표로 기록하고 예외를 다시 던진다")
+        void fail_databaseUnavailable() {
             // given
-            given(alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches())
+            given(alarmLocationCacheCleanupService.removeExpiredGoogleLocationCaches())
                 .willThrow(new IllegalStateException("database unavailable"));
 
             // when
-            org.assertj.core.api.Assertions.assertThatThrownBy(scheduler::clearExpiredGoogleLocationCaches)
+            org.assertj.core.api.Assertions.assertThatThrownBy(scheduler::removeExpiredGoogleLocationCaches)
                 .isInstanceOf(IllegalStateException.class);
 
             // then

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -366,7 +366,7 @@ class AlarmCommandServiceTest {
                     "google-place-id", "새 장소", 37.5663, 126.9779, FIXED_NOW
                 );
                 return null;
-            }).when(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            }).when(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
 
             // when
             alarmCommandService.checkinAlarm(
@@ -374,7 +374,7 @@ class AlarmCommandServiceTest {
             );
 
             // then
-            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            verify(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
             assertThat(occurrence.getStatus()).isEqualTo(OccurrenceStatus.CHECKIN);
         }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmCommandServiceTest.java
@@ -12,7 +12,9 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import akuma.whiplash.common.fixture.AlarmOccurrenceFixture;
 import akuma.whiplash.common.fixture.AlarmFixture;
@@ -36,6 +38,7 @@ import akuma.whiplash.domains.alarm.application.dto.response.AlarmPaymentRespons
 import akuma.whiplash.domains.alarm.application.dto.response.CreateAlarmResponse;
 import akuma.whiplash.domains.alarm.application.service.AuditLogRecorder;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.DeleteType;
 import akuma.whiplash.domains.alarm.domain.constant.OccurrenceStatus;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
@@ -107,6 +110,8 @@ class AlarmCommandServiceTest {
     private TimeProvider timeProvider;
     @Mock
     private AuditLogRecorder auditLogRecorder;
+    @Mock
+    private AlarmLocationCacheService alarmLocationCacheService;
 
     @InjectMocks
     private AlarmCommandServiceImpl alarmCommandService;
@@ -138,7 +143,9 @@ class AlarmCommandServiceTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -156,6 +163,38 @@ class AlarmCommandServiceTest {
         }
 
         @Test
+        @DisplayName("성공: Google 장소 위치를 요청 값으로 캐시하고 재조회하지 않는다")
+        void success_cacheGooglePlaceLocationWithoutRefresh() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_5.toMockEntity();
+            AlarmFixture fixture = AlarmFixture.ALARM_05;
+            AlarmRegisterRequest request = new AlarmRegisterRequest(
+                new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
+                    fixture.getAddress(), fixture.getLatitude(), fixture.getLongitude(), "google-place-id", "session-token"
+                ),
+                fixture.getAlarmPurpose(),
+                fixture.getTime(),
+                fixture.getRepeatDays().stream().map(Weekday::name).toList(),
+                fixture.getSoundType().name()
+            );
+            given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+            // when
+            alarmCommandService.createAlarm(request, member.getId(), "device-uuid");
+
+            // then
+            ArgumentCaptor<AlarmEntity> captor = ArgumentCaptor.forClass(AlarmEntity.class);
+            verify(alarmRepository).save(captor.capture());
+            assertThat(captor.getValue().getLocationSource()).isEqualTo(LocationSource.GOOGLE_PLACE);
+            assertThat(captor.getValue().getGooglePlaceId()).isEqualTo("google-place-id");
+            assertThat(captor.getValue().getAddress()).isEqualTo(fixture.getAddress());
+            assertThat(captor.getValue().getLatitude()).isEqualTo(fixture.getLatitude());
+            assertThat(captor.getValue().getLongitude()).isEqualTo(fixture.getLongitude());
+            assertThat(captor.getValue().getLocationCachedAt()).isEqualTo(FIXED_NOW);
+            verifyNoInteractions(alarmLocationCacheService);
+        }
+
+        @Test
         @DisplayName("성공: 요청 기기 timeZone 기준으로 첫 발생 내역의 예정 시각을 저장한다")
         void success_createFirstOccurrenceByRequestDeviceTimeZone() {
             // given
@@ -165,7 +204,9 @@ class AlarmCommandServiceTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -210,7 +251,9 @@ class AlarmCommandServiceTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -236,7 +279,9 @@ class AlarmCommandServiceTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -296,6 +341,41 @@ class AlarmCommandServiceTest {
             assertThat(response.nextOccurrence()).isNotNull();
             assertThat(response.nextOccurrence().occurrenceId()).isEqualTo(502L);
             verify(eventPublisher).publishEvent(any(AlarmCheckinCompletedEvent.class));
+        }
+
+        @Test
+        @DisplayName("성공: 만료된 Google 장소 캐시는 인증 전에 재조회한다")
+        void success_refreshExpiredGooglePlaceCache() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_10.toMockEntity();
+            AlarmEntity alarm = buildAlarm(member, AlarmFixture.ALARM_10);
+            alarm.updateGooglePlaceLocation(
+                "google-place-id", alarm.getAddress(), alarm.getLatitude(), alarm.getLongitude(), FIXED_NOW.minusDays(29)
+            );
+            AlarmOccurrenceEntity occurrence = buildOccurrence(alarm, 503L, FIXED_NOW.plusHours(1), OccurrenceStatus.SCHEDULED);
+            given(alarmRepository.findById(alarm.getId())).willReturn(Optional.of(alarm));
+            given(alarmOccurrenceRepository.findByIdAndAlarmId(occurrence.getId(), alarm.getId()))
+                .willReturn(Optional.of(occurrence));
+            given(alarmOccurrenceRepository.findNextScheduledByAlarmIds(
+                eq(List.of(alarm.getId())), eq(OccurrenceStatus.SCHEDULED), any(LocalDateTime.class)
+            )).willReturn(List.of());
+            given(alarmLocationCacheService.hasValidGoogleLocationCache(alarm, FIXED_NOW)).willReturn(false);
+            doAnswer(invocation -> {
+                AlarmEntity target = invocation.getArgument(0);
+                target.updateGooglePlaceLocation(
+                    "google-place-id", "새 장소", 37.5663, 126.9779, FIXED_NOW
+                );
+                return null;
+            }).when(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+
+            // when
+            alarmCommandService.checkinAlarm(
+                member.getId(), alarm.getId(), buildRequest(occurrence, 37.5663, 126.9779)
+            );
+
+            // then
+            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            assertThat(occurrence.getStatus()).isEqualTo(OccurrenceStatus.CHECKIN);
         }
 
         @Test

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupServiceTest.java
@@ -8,6 +8,7 @@ import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
 import akuma.whiplash.global.util.date.TimeProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,19 +26,24 @@ class AlarmLocationCacheCleanupServiceTest {
     @InjectMocks
     private AlarmLocationCacheCleanupService alarmLocationCacheCleanupService;
 
-    @Test
-    @DisplayName("성공: 29일 지난 Google 장소 캐시만 삭제한다")
-    void success() {
-        // given
-        LocalDateTime now = LocalDateTime.of(2026, 7, 25, 12, 0);
-        given(timeProvider.now()).willReturn(now);
+    @Nested
+    @DisplayName("만료된 Google 장소 위치 캐시를 삭제한다")
+    class RemoveExpiredGoogleLocationCachesTest {
 
-        // when
-        alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches();
+        @Test
+        @DisplayName("성공: 29일 지난 Google 장소 캐시만 삭제한다")
+        void success() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 7, 25, 12, 0);
+            given(timeProvider.now()).willReturn(now);
 
-        // then
-        verify(alarmRepository).clearLocationCachesBySourceAndCachedAtBefore(
-            LocationSource.GOOGLE_PLACE, now.minusDays(29)
-        );
+            // when
+            alarmLocationCacheCleanupService.removeExpiredGoogleLocationCaches();
+
+            // then
+            verify(alarmRepository).updateLocationCachesBySourceAndCachedAtBefore(
+                LocationSource.GOOGLE_PLACE, now.minusDays(29)
+            );
+        }
     }
 }

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheCleanupServiceTest.java
@@ -1,0 +1,43 @@
+package akuma.whiplash.domains.alarm.domain.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
+import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository;
+import akuma.whiplash.global.util.date.TimeProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlarmLocationCacheCleanupService Unit Test")
+class AlarmLocationCacheCleanupServiceTest {
+
+    @Mock
+    private AlarmRepository alarmRepository;
+    @Mock
+    private TimeProvider timeProvider;
+    @InjectMocks
+    private AlarmLocationCacheCleanupService alarmLocationCacheCleanupService;
+
+    @Test
+    @DisplayName("성공: 29일 지난 Google 장소 캐시만 삭제한다")
+    void success() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 7, 25, 12, 0);
+        given(timeProvider.now()).willReturn(now);
+
+        // when
+        alarmLocationCacheCleanupService.clearExpiredGoogleLocationCaches();
+
+        // then
+        verify(alarmRepository).clearLocationCachesBySourceAndCachedAtBefore(
+            LocationSource.GOOGLE_PLACE, now.minusDays(29)
+        );
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheServiceTest.java
@@ -1,0 +1,106 @@
+package akuma.whiplash.domains.alarm.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import akuma.whiplash.common.fixture.AlarmFixture;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
+import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
+import akuma.whiplash.domains.place.domain.client.GoogleClient;
+import akuma.whiplash.domains.place.domain.model.PlaceDetailsCriteria;
+import akuma.whiplash.domains.place.domain.model.SelectedPlaceDetail;
+import akuma.whiplash.global.util.date.TimeProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlarmLocationCacheService Unit Test")
+class AlarmLocationCacheServiceTest {
+
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 7, 25, 12, 0);
+
+    @Mock
+    private GoogleClient googleClient;
+    @Mock
+    private TimeProvider timeProvider;
+    @InjectMocks
+    private AlarmLocationCacheService alarmLocationCacheService;
+
+    @Nested
+    @DisplayName("hasValidGoogleLocationCache - 캐시 유효성 판단")
+    class HasValidGoogleLocationCacheTest {
+
+        @Test
+        @DisplayName("성공: 저장 후 29일 전의 Google 장소 캐시는 유효하다")
+        void success() {
+            // given
+            AlarmEntity alarm = googlePlaceAlarm(FIXED_NOW.minusDays(28).plusSeconds(1));
+
+            // when
+            boolean result = alarmLocationCacheService.hasValidGoogleLocationCache(alarm, FIXED_NOW);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 저장 후 29일이 지난 Google 장소 캐시는 만료된다")
+        void success_expiredAfterTwentyNineDays() {
+            // given
+            AlarmEntity alarm = googlePlaceAlarm(FIXED_NOW.minusDays(29));
+
+            // when
+            boolean result = alarmLocationCacheService.hasValidGoogleLocationCache(alarm, FIXED_NOW);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("refreshGoogleLocationCache - Google 장소 캐시 갱신")
+    class RefreshGoogleLocationCacheTest {
+
+        @Test
+        @DisplayName("성공: Place ID로 조회한 좌표와 주소를 새 캐시로 저장한다")
+        void success() {
+            // given
+            AlarmEntity alarm = googlePlaceAlarm(FIXED_NOW.minusDays(29));
+            SelectedPlaceDetail detail = new SelectedPlaceDetail(
+                "서울특별시 중구 세종대로 110", 37.5663, 126.9779, "KR", "google-place-id"
+            );
+            given(timeProvider.now()).willReturn(FIXED_NOW);
+            given(googleClient.getPlaceDetails(new PlaceDetailsCriteria("google-place-id", null, null, null)))
+                .willReturn(detail);
+
+            // when
+            alarmLocationCacheService.refreshGoogleLocationCache(alarm);
+
+            // then
+            verify(googleClient).getPlaceDetails(new PlaceDetailsCriteria("google-place-id", null, null, null));
+            assertThat(alarm.getLatitude()).isEqualTo(37.5663);
+            assertThat(alarm.getLongitude()).isEqualTo(126.9779);
+            assertThat(alarm.getAddress()).isEqualTo("서울특별시 중구 세종대로 110");
+            assertThat(alarm.getLocationCachedAt()).isEqualTo(FIXED_NOW);
+        }
+    }
+
+    private AlarmEntity googlePlaceAlarm(LocalDateTime cachedAt) {
+        AlarmEntity alarm = AlarmFixture.ALARM_01.toMockEntity();
+        alarm.updateGooglePlaceLocation(
+            "google-place-id",
+            alarm.getAddress(),
+            alarm.getLatitude(),
+            alarm.getLongitude(),
+            cachedAt
+        );
+        return alarm;
+    }
+}

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmLocationCacheServiceTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("AlarmLocationCacheService Unit Test")
+@DisplayName("Google 장소 위치 캐시를 관리한다")
 class AlarmLocationCacheServiceTest {
 
     private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 7, 25, 12, 0);
@@ -30,11 +30,13 @@ class AlarmLocationCacheServiceTest {
     private GoogleClient googleClient;
     @Mock
     private TimeProvider timeProvider;
+    @Mock
+    private AlarmLocationCachePersistenceService alarmLocationCachePersistenceService;
     @InjectMocks
     private AlarmLocationCacheService alarmLocationCacheService;
 
     @Nested
-    @DisplayName("hasValidGoogleLocationCache - 캐시 유효성 판단")
+    @DisplayName("Google 장소 위치 캐시 유효성을 판단한다")
     class HasValidGoogleLocationCacheTest {
 
         @Test
@@ -65,8 +67,8 @@ class AlarmLocationCacheServiceTest {
     }
 
     @Nested
-    @DisplayName("refreshGoogleLocationCache - Google 장소 캐시 갱신")
-    class RefreshGoogleLocationCacheTest {
+    @DisplayName("Google 장소 위치 캐시를 갱신한다")
+    class ModifyGoogleLocationCacheTest {
 
         @Test
         @DisplayName("성공: Place ID로 조회한 좌표와 주소를 새 캐시로 저장한다")
@@ -81,7 +83,7 @@ class AlarmLocationCacheServiceTest {
                 .willReturn(detail);
 
             // when
-            alarmLocationCacheService.refreshGoogleLocationCache(alarm);
+            alarmLocationCacheService.modifyGoogleLocationCache(alarm);
 
             // then
             verify(googleClient).getPlaceDetails(new PlaceDetailsCriteria("google-place-id", null, null, null));
@@ -89,6 +91,8 @@ class AlarmLocationCacheServiceTest {
             assertThat(alarm.getLongitude()).isEqualTo(126.9779);
             assertThat(alarm.getAddress()).isEqualTo("서울특별시 중구 세종대로 110");
             assertThat(alarm.getLocationCachedAt()).isEqualTo(FIXED_NOW);
+            verify(alarmLocationCachePersistenceService)
+                .modifyGoogleLocationCache(alarm.getId(), detail, FIXED_NOW);
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import akuma.whiplash.common.fixture.AlarmFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
@@ -58,6 +59,7 @@ class AlarmQueryServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private MemberDeviceRepository memberDeviceRepository;
     @Mock private TimeProvider timeProvider;
+    @Mock private AlarmLocationCacheService alarmLocationCacheService;
 
     @InjectMocks private AlarmQueryServiceImpl alarmQueryService;
 
@@ -103,6 +105,29 @@ class AlarmQueryServiceTest {
                 .isEqualTo(LocalDate.of(2026, 5, 4));
             assertThat(result.alarms().get(0).nextOccurrence().scheduledTime()).isEqualTo("06:40");
             assertThat(result.alarms().get(0).nextOccurrence().scheduledAtUtc()).isEqualTo("2026-05-03T21:40:00Z");
+        }
+
+        @Test
+        @DisplayName("성공: 주소 캐시가 없는 Google 장소는 응답 전에 Place ID로 갱신한다")
+        void success_refreshMissingGooglePlaceAddress() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity();
+            alarm.updateGooglePlaceLocation("google-place-id", null, 37.4968, 127.0137, FIXED_NOW.minusDays(29));
+            given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+            given(alarmRepository.findAllByMemberIdAndStatusNot(member.getId(), AlarmStatus.DELETED))
+                .willReturn(List.of(alarm));
+            given(alarmLocationCacheService.canRefreshGoogleLocationCache(alarm)).willReturn(true);
+            given(alarmOccurrenceRepository.findLatestProcessedByAlarmIds(anyList(), anyList()))
+                .willReturn(List.of());
+            given(alarmOccurrenceRepository.findByAlarmIdsAndOccurrenceDates(anyList(), anyList()))
+                .willReturn(List.of());
+
+            // when
+            alarmQueryService.getAlarms(member.getId(), REQUEST_DEVICE_ID);
+
+            // then
+            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
         }
 
         @Test

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
@@ -128,7 +128,7 @@ class AlarmQueryServiceTest {
             alarmQueryService.getAlarms(member.getId(), REQUEST_DEVICE_ID);
 
             // then
-            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            verify(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
         }
 
         @Test
@@ -442,14 +442,75 @@ class AlarmQueryServiceTest {
             doAnswer(invocation -> {
                 alarm.updateGooglePlaceLocation("google-place-id", "서울", 37.5, 127.0, FIXED_NOW);
                 return null;
-            }).when(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            }).when(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
 
             // when
             List<OccurrencePushInfo> result = alarmQueryService.getPreNotificationTargets(start, end);
 
             // then
-            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            verify(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
             assertThat(result).containsExactly(new OccurrencePushInfo(1L, 2L, 3L, "서울"));
+        }
+
+        @Test
+        @DisplayName("성공: 만료된 캐시는 사전 알림 전에 Google 장소 캐시를 갱신한다")
+        void success_refreshesExpiredGooglePlaceCache() {
+            // given
+            LocalDateTime start = FIXED_NOW.plusMinutes(59);
+            LocalDateTime end = FIXED_NOW.plusMinutes(61);
+            OccurrencePushInfo info = new OccurrencePushInfo(1L, 2L, 3L, "기존 주소");
+            AlarmEntity alarm = AlarmFixture.ALARM_03.toMockEntity();
+            given(alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
+                start,
+                end,
+                OccurrenceStatus.SCHEDULED
+            )).willReturn(List.of(info));
+            given(alarmRepository.findAllById(List.of(3L))).willReturn(List.of(alarm));
+            given(alarmLocationCacheService.hasValidGoogleLocationCache(any(), any())).willReturn(false);
+            given(alarmLocationCacheService.canRefreshGoogleLocationCache(alarm)).willReturn(true);
+            doAnswer(invocation -> {
+                alarm.updateGooglePlaceLocation("google-place-id", "새 주소", 37.5, 127.0, FIXED_NOW);
+                return null;
+            }).when(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
+
+            // when
+            List<OccurrencePushInfo> result = alarmQueryService.getPreNotificationTargets(start, end);
+
+            // then
+            verify(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
+            assertThat(result).containsExactly(new OccurrencePushInfo(1L, 2L, 3L, "새 주소"));
+        }
+
+        @Test
+        @DisplayName("성공: Google 장소 캐시 갱신에 실패해도 주소 없는 사전 알림 대상을 반환한다")
+        void success_returnsAddresslessTargetWhenGoogleCacheRefreshFails() {
+            // given
+            LocalDateTime start = FIXED_NOW.plusMinutes(59);
+            LocalDateTime end = FIXED_NOW.plusMinutes(61);
+            OccurrencePushInfo info = new OccurrencePushInfo(1L, 2L, 3L, null);
+            AlarmEntity alarm = AlarmFixture.ALARM_03.toMockEntity();
+            alarm.updateGooglePlaceLocation(
+                "google-place-id", alarm.getAddress(), 37.5, 127.0, FIXED_NOW.minusDays(29)
+            );
+            given(alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
+                start,
+                end,
+                OccurrenceStatus.SCHEDULED
+            )).willReturn(List.of(info));
+            given(alarmRepository.findAllById(List.of(3L))).willReturn(List.of(alarm));
+            given(alarmLocationCacheService.hasValidGoogleLocationCache(any(), any())).willReturn(false);
+            given(alarmLocationCacheService.canRefreshGoogleLocationCache(alarm)).willReturn(true);
+            doAnswer(invocation -> {
+                alarm.clearGooglePlaceLocationCache();
+                throw new IllegalStateException("Google Places unavailable");
+            }).when(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
+
+            // when
+            List<OccurrencePushInfo> result = alarmQueryService.getPreNotificationTargets(start, end);
+
+            // then
+            verify(alarmLocationCacheService).modifyGoogleLocationCache(alarm);
+            assertThat(result).containsExactly(info);
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/domain/service/AlarmQueryServiceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import akuma.whiplash.common.fixture.AlarmFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
@@ -58,6 +60,7 @@ class AlarmQueryServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private MemberDeviceRepository memberDeviceRepository;
     @Mock private TimeProvider timeProvider;
+    @Mock private AlarmLocationCacheService alarmLocationCacheService;
 
     @InjectMocks private AlarmQueryServiceImpl alarmQueryService;
 
@@ -103,6 +106,29 @@ class AlarmQueryServiceTest {
                 .isEqualTo(LocalDate.of(2026, 5, 4));
             assertThat(result.alarms().get(0).nextOccurrence().scheduledTime()).isEqualTo("06:40");
             assertThat(result.alarms().get(0).nextOccurrence().scheduledAtUtc()).isEqualTo("2026-05-03T21:40:00Z");
+        }
+
+        @Test
+        @DisplayName("성공: 주소 캐시가 없는 Google 장소는 응답 전에 Place ID로 갱신한다")
+        void success_refreshMissingGooglePlaceAddress() {
+            // given
+            MemberEntity member = MemberFixture.MEMBER_11.toMockEntity();
+            AlarmEntity alarm = AlarmFixture.ALARM_11.toMockEntity();
+            alarm.updateGooglePlaceLocation("google-place-id", null, 37.4968, 127.0137, FIXED_NOW.minusDays(29));
+            given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+            given(alarmRepository.findAllByMemberIdAndStatusNot(member.getId(), AlarmStatus.DELETED))
+                .willReturn(List.of(alarm));
+            given(alarmLocationCacheService.canRefreshGoogleLocationCache(alarm)).willReturn(true);
+            given(alarmOccurrenceRepository.findLatestProcessedByAlarmIds(anyList(), anyList()))
+                .willReturn(List.of());
+            given(alarmOccurrenceRepository.findByAlarmIdsAndOccurrenceDates(anyList(), anyList()))
+                .willReturn(List.of());
+
+            // when
+            alarmQueryService.getAlarms(member.getId(), REQUEST_DEVICE_ID);
+
+            // then
+            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
         }
 
         @Test
@@ -383,7 +409,7 @@ class AlarmQueryServiceTest {
             // given
             LocalDateTime start = FIXED_NOW.plusMinutes(59);
             LocalDateTime end = FIXED_NOW.plusMinutes(61);
-            OccurrencePushInfo info = new OccurrencePushInfo(1L, 2L, "서울");
+            OccurrencePushInfo info = new OccurrencePushInfo(1L, 2L, 3L, "서울");
             given(alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
                 start,
                 end,
@@ -395,6 +421,35 @@ class AlarmQueryServiceTest {
 
             // then
             assertThat(result).containsExactly(info);
+        }
+
+        @Test
+        @DisplayName("성공: 주소 캐시가 없으면 사전 알림 전에 Google 장소 캐시를 갱신한다")
+        void success_refreshesMissingGooglePlaceAddress() {
+            // given
+            LocalDateTime start = FIXED_NOW.plusMinutes(59);
+            LocalDateTime end = FIXED_NOW.plusMinutes(61);
+            OccurrencePushInfo info = new OccurrencePushInfo(1L, 2L, 3L, null);
+            AlarmEntity alarm = AlarmFixture.ALARM_03.toMockEntity();
+            alarm.updateGooglePlaceLocation("google-place-id", null, 37.5, 127.0, FIXED_NOW.minusDays(29));
+            given(alarmOccurrenceRepository.findPreNotificationTargetsByScheduledAtBetween(
+                start,
+                end,
+                OccurrenceStatus.SCHEDULED
+            )).willReturn(List.of(info));
+            given(alarmRepository.findAllById(List.of(3L))).willReturn(List.of(alarm));
+            given(alarmLocationCacheService.canRefreshGoogleLocationCache(alarm)).willReturn(true);
+            doAnswer(invocation -> {
+                alarm.updateGooglePlaceLocation("google-place-id", "서울", 37.5, 127.0, FIXED_NOW);
+                return null;
+            }).when(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+
+            // when
+            List<OccurrencePushInfo> result = alarmQueryService.getPreNotificationTargets(start, end);
+
+            // then
+            verify(alarmLocationCacheService).refreshGoogleLocationCache(alarm);
+            assertThat(result).containsExactly(new OccurrencePushInfo(1L, 2L, 3L, "서울"));
         }
     }
 

--- a/src/test/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepositoryTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepositoryTest.java
@@ -6,12 +6,15 @@ import akuma.whiplash.common.config.PersistenceTest;
 import akuma.whiplash.common.fixture.AlarmFixture;
 import akuma.whiplash.common.fixture.MemberFixture;
 import akuma.whiplash.domains.alarm.domain.constant.AlarmStatus;
+import akuma.whiplash.domains.alarm.domain.constant.LocationSource;
 import akuma.whiplash.domains.alarm.domain.constant.SoundType;
 import akuma.whiplash.domains.alarm.domain.constant.Weekday;
 import akuma.whiplash.domains.alarm.persistence.entity.AlarmEntity;
 import akuma.whiplash.domains.alarm.persistence.repository.AlarmRepository.AlarmOccurrenceBatchTarget;
 import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +29,8 @@ class AlarmRepositoryTest {
     private AlarmRepository alarmRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private EntityManager entityManager;
 
     @Nested
     @DisplayName("findAllByMemberId - 회원 ID로 알람 조회")
@@ -102,4 +107,44 @@ class AlarmRepositoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("clearLocationCachesBySourceAndCachedAtBefore - 만료 위치 캐시 정리")
+    class ClearLocationCachesBySourceAndCachedAtBeforeTest {
+
+        @Test
+        @DisplayName("성공: 만료된 Google 장소 캐시만 삭제하고 Place ID는 남긴다")
+        void success() {
+            // given
+            MemberEntity member = memberRepository.save(MemberFixture.MEMBER_8.toEntity());
+            AlarmEntity googlePlaceAlarm = AlarmFixture.ALARM_08.toEntity(member);
+            googlePlaceAlarm.updateGooglePlaceLocation(
+                "google-place-id",
+                googlePlaceAlarm.getAddress(),
+                googlePlaceAlarm.getLatitude(),
+                googlePlaceAlarm.getLongitude(),
+                LocalDateTime.of(2026, 6, 26, 12, 0)
+            );
+            AlarmEntity legacyAlarm = AlarmFixture.ALARM_09.toEntity(member);
+            alarmRepository.saveAndFlush(googlePlaceAlarm);
+            alarmRepository.saveAndFlush(legacyAlarm);
+
+            // when
+            int clearedCount = alarmRepository.clearLocationCachesBySourceAndCachedAtBefore(
+                LocationSource.GOOGLE_PLACE,
+                LocalDateTime.of(2026, 7, 25, 12, 0)
+            );
+            entityManager.clear();
+
+            // then
+            AlarmEntity clearedAlarm = alarmRepository.findById(googlePlaceAlarm.getId()).orElseThrow();
+            AlarmEntity retainedLegacyAlarm = alarmRepository.findById(legacyAlarm.getId()).orElseThrow();
+            assertThat(clearedCount).isEqualTo(1);
+            assertThat(clearedAlarm.getGooglePlaceId()).isEqualTo("google-place-id");
+            assertThat(clearedAlarm.getLatitude()).isNull();
+            assertThat(clearedAlarm.getLongitude()).isNull();
+            assertThat(clearedAlarm.getAddress()).isNull();
+            assertThat(clearedAlarm.getLocationCachedAt()).isNull();
+            assertThat(retainedLegacyAlarm.getLatitude()).isNotNull();
+        }
+    }
 }

--- a/src/test/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepositoryTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/persistence/repository/AlarmRepositoryTest.java
@@ -108,7 +108,7 @@ class AlarmRepositoryTest {
     }
 
     @Nested
-    @DisplayName("clearLocationCachesBySourceAndCachedAtBefore - 만료 위치 캐시 정리")
+    @DisplayName("updateLocationCachesBySourceAndCachedAtBefore - 만료 위치 캐시 정리")
     class ClearLocationCachesBySourceAndCachedAtBeforeTest {
 
         @Test
@@ -129,7 +129,7 @@ class AlarmRepositoryTest {
             alarmRepository.saveAndFlush(legacyAlarm);
 
             // when
-            int clearedCount = alarmRepository.clearLocationCachesBySourceAndCachedAtBefore(
+            int clearedCount = alarmRepository.updateLocationCachesBySourceAndCachedAtBefore(
                 LocationSource.GOOGLE_PLACE,
                 LocalDateTime.of(2026, 7, 25, 12, 0)
             );

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerIntegrationTest.java
@@ -42,6 +42,8 @@ import akuma.whiplash.domains.member.persistence.entity.MemberEntity;
 import akuma.whiplash.domains.member.persistence.repository.MemberDeviceRepository;
 import akuma.whiplash.domains.member.persistence.repository.MemberRepository;
 import akuma.whiplash.domains.payment.persistence.repository.PaymentRepository;
+import akuma.whiplash.domains.place.domain.client.GoogleClient;
+import akuma.whiplash.domains.place.domain.model.SelectedPlaceDetail;
 import akuma.whiplash.global.config.security.jwt.JwtProvider;
 import akuma.whiplash.global.util.date.TimeProvider;
 import akuma.whiplash.infrastructure.payment.PaymentVerificationPort;
@@ -85,6 +87,7 @@ class AlarmControllerIntegrationTest {
     @Autowired private PaymentRepository paymentRepository;
     @MockitoBean private PaymentVerificationPort paymentVerificationPort;
     @MockitoBean private TimeProvider timeProvider;
+    @MockitoBean private GoogleClient googleClient;
 
     private static final String BASE = "/api/v1/alarms";
     private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 5, 4, 11, 0);
@@ -109,6 +112,9 @@ class AlarmControllerIntegrationTest {
         given(timeProvider.now(any(ZoneId.class))).willReturn(FIXED_NOW);
         given(timeProvider.today(any(ZoneId.class))).willReturn(FIXED_NOW.toLocalDate());
         given(timeProvider.instant()).willReturn(FIXED_NOW.atZone(ZoneId.of("Asia/Seoul")).toInstant());
+        given(googleClient.getPlaceDetails(any())).willReturn(new SelectedPlaceDetail(
+            "서울특별시 중구 퇴계로 24", 37.564213, 127.001698, "KR", "google-place-id"
+        ));
     }
 
     private AlarmEntity saveAlarmForToday(MemberEntity member) {
@@ -121,6 +127,7 @@ class AlarmControllerIntegrationTest {
             .latitude(37.5665)
             .longitude(126.9780)
             .address("서울특별시 중구 퇴계로 123")
+            .locationSource(LocationSource.USER_PIN)
             .member(member)
             .build());
     }
@@ -150,6 +157,7 @@ class AlarmControllerIntegrationTest {
             .latitude(37.5665)
             .longitude(126.9780)
             .address("서울특별시 중구 퇴계로 123")
+            .locationSource(LocationSource.USER_PIN)
             .member(member)
             .build());
     }
@@ -196,7 +204,9 @@ class AlarmControllerIntegrationTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     "서울특별시 중구 퇴계로 24",
                     37.564213,
-                    127.001698
+                    127.001698,
+                    "google-place-id",
+                    null
                 ),
                 "월요일 점심 알람",
                 LocalTime.of(12, 0),
@@ -232,7 +242,9 @@ class AlarmControllerIntegrationTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -260,7 +272,9 @@ class AlarmControllerIntegrationTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),

--- a/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/akuma/whiplash/domains/alarm/presentation/AlarmControllerTest.java
@@ -136,7 +136,9 @@ class AlarmControllerTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 LocalTime.parse("08:30"),
@@ -170,7 +172,8 @@ class AlarmControllerTest {
                   "place": {
                     "address": "서울시 중구 퇴계로 24",
                     "latitude": 37.564213,
-                    "longitude": 127.001698
+                    "longitude": 127.001698,
+                    "googlePlaceId": "google-place-id"
                   },
                   "alarmPurpose": "도서관 정기 출석 알람",
                   "alarmTime": "24:30",
@@ -204,7 +207,9 @@ class AlarmControllerTest {
                 new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                     fixture.getAddress(),
                     fixture.getLatitude(),
-                    fixture.getLongitude()
+                    fixture.getLongitude(),
+                    "google-place-id",
+                    null
                 ),
                 fixture.getAlarmPurpose(),
                 fixture.getTime(),
@@ -235,7 +240,9 @@ class AlarmControllerTest {
             new akuma.whiplash.domains.alarm.application.dto.request.PlaceRequest(
                 fixture.getAddress(),
                 fixture.getLatitude(),
-                fixture.getLongitude()
+                fixture.getLongitude(),
+                "google-place-id",
+                null
             ),
             fixture.getAlarmPurpose(),
             fixture.getTime(),

--- a/src/test/java/akuma/whiplash/global/log/LogUtilsTest.java
+++ b/src/test/java/akuma/whiplash/global/log/LogUtilsTest.java
@@ -27,6 +27,8 @@ class LogUtilsTest {
                   "paymentId": "payment-success-001",
                   "adProofToken": "ad-proof-token",
                   "sessionToken": "session-token",
+                  "session_token": "snake-session-token",
+                  "google_place_id": "snake-google-place-id",
                   "fcmToken": "fcm-token",
                   "nested": {
                     "deviceId": "device-uuid"
@@ -43,6 +45,8 @@ class LogUtilsTest {
             assertThat(result).contains("\"paymentId\":\"****\"");
             assertThat(result).contains("\"adProofToken\":\"****\"");
             assertThat(result).contains("\"sessionToken\":\"****\"");
+            assertThat(result).contains("\"session_token\":\"****\"");
+            assertThat(result).contains("\"google_place_id\":\"****\"");
             assertThat(result).contains("\"fcmToken\":\"****\"");
             assertThat(result).contains("\"deviceId\":\"****\"");
             assertThat(result).doesNotContain("37.4847");
@@ -58,13 +62,13 @@ class LogUtilsTest {
         @DisplayName("성공: query string의 좌표와 결제 식별자를 마스킹한다")
         void success() {
             // given
-            String query = "latitude=37.4847&longitude=126.9294&paymentId=payment-success-001&googlePlaceId=ChIJ123&sessionToken=session-token&query=cafe";
+            String query = "latitude=37.4847&longitude=126.9294&paymentId=payment-success-001&googlePlaceId=ChIJ123&sessionToken=session-token&session_token=snake-session-token&google_place_id=snake-google-place-id&query=cafe";
 
             // when
             String result = LogUtils.maskSensitiveQuery(query);
 
             // then
-            assertThat(result).isEqualTo("latitude=****&longitude=****&paymentId=****&googlePlaceId=****&sessionToken=****&query=cafe");
+            assertThat(result).isEqualTo("latitude=****&longitude=****&paymentId=****&googlePlaceId=****&sessionToken=****&session_token=****&google_place_id=****&query=cafe");
         }
     }
 }

--- a/src/test/java/akuma/whiplash/global/log/LogUtilsTest.java
+++ b/src/test/java/akuma/whiplash/global/log/LogUtilsTest.java
@@ -26,6 +26,7 @@ class LogUtilsTest {
                   "longitude": 126.9294,
                   "paymentId": "payment-success-001",
                   "adProofToken": "ad-proof-token",
+                  "sessionToken": "session-token",
                   "fcmToken": "fcm-token",
                   "nested": {
                     "deviceId": "device-uuid"
@@ -41,6 +42,7 @@ class LogUtilsTest {
             assertThat(result).contains("\"longitude\":\"****\"");
             assertThat(result).contains("\"paymentId\":\"****\"");
             assertThat(result).contains("\"adProofToken\":\"****\"");
+            assertThat(result).contains("\"sessionToken\":\"****\"");
             assertThat(result).contains("\"fcmToken\":\"****\"");
             assertThat(result).contains("\"deviceId\":\"****\"");
             assertThat(result).doesNotContain("37.4847");
@@ -56,13 +58,13 @@ class LogUtilsTest {
         @DisplayName("성공: query string의 좌표와 결제 식별자를 마스킹한다")
         void success() {
             // given
-            String query = "latitude=37.4847&longitude=126.9294&paymentId=payment-success-001&query=cafe";
+            String query = "latitude=37.4847&longitude=126.9294&paymentId=payment-success-001&googlePlaceId=ChIJ123&sessionToken=session-token&query=cafe";
 
             // when
             String result = LogUtils.maskSensitiveQuery(query);
 
             // then
-            assertThat(result).isEqualTo("latitude=****&longitude=****&paymentId=****&query=cafe");
+            assertThat(result).isEqualTo("latitude=****&longitude=****&paymentId=****&googlePlaceId=****&sessionToken=****&query=cafe");
         }
     }
 }

--- a/src/test/java/akuma/whiplash/infrastructure/firebase/FcmServiceTest.java
+++ b/src/test/java/akuma/whiplash/infrastructure/firebase/FcmServiceTest.java
@@ -1,7 +1,7 @@
 package akuma.whiplash.infrastructure.firebase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -57,5 +57,11 @@ class FcmServiceTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("redis error");
         }
+    }
+
+    @Test
+    @DisplayName("성공: 주소가 없으면 일반 사전 알림 문구를 생성한다")
+    void success_returnsGenericPreAlarmBodyWithoutAddress() {
+        assertThat(FcmService.getPreAlarmBody(null)).isEqualTo("1시간 뒤 알람이 울릴 예정이에요!");
     }
 }


### PR DESCRIPTION
## 📄 PR 요약

Google Maps 정책 준수를 위해 알람 장소 데이터 저장 방식을 개선했습니다.

- `googlePlaceId`는 영구 저장
- 주소·위도·경도는 최대 29일 캐시 후 삭제
- 캐시 누락·만료 시 목록 조회, 위치 인증, 사전 푸시 전에 Google Place Details로 갱신

## ✍🏻 PR 상세

1. DB 및 마이그레이션
   - `alarm` 테이블에 `location_source`, `google_place_id`, `location_cached_at` 추가
   - 주소·위도·경도를 nullable 캐시 데이터로 전환
   - 기존 알람의 주소·좌표 캐시를 제거하고 `GOOGLE_PLACE` 출처로 마이그레이션

2. 알람 등록 및 위치 캐시
   - 앱이 장소 검색/상세 조회에서 받은 주소·좌표를 등록 시점에 캐시
   - 등록 단계의 중복 Google Place Details 호출 제거
   - 캐시 유효 기간을 29일로 적용

3. 캐시 갱신 및 정리
   - 만료 캐시를 매 시간 정리하는 scheduler 추가
   - 목록 조회, 위치 인증, 사전 푸시 전 주소 누락 시 `googlePlaceId` 기반 lazy refresh
   - cleanup 처리 건수·성공/실패·소요 시간·마지막 성공 시각 메트릭 추가

4. 예외 및 데이터 보호
   - `googlePlaceId`가 없는 기존 알람은 위치 인증 시 `ALARM_014` 반환
   - `sessionToken` 로그 마스킹 적용
   - archive 데이터에 Google 장소 주소·좌표를 남기지 않도록 처리

5. 테스트
   - 캐시 만료·정리·재조회·위치 인증·사전 푸시 갱신 케이스 추가
   - `./gradlew test`, `git diff --check` 통과

## 👀 참고사항

- 실제 MySQL/Flyway migration 적용 검증은 QA 환경에서 별도 진행이 필요합니다.
- `deleted_alarm` 운영 DDL의 주소·좌표 nullable 여부 확인이 필요합니다.
- `googlePlaceId`가 없는 기존 알람은 Google 위치 캐시를 갱신할 수 없으므로, 앱에서 `ALARM_014` 수신 시 장소 재선택 UX가 필요합니다.

## 🚪 연관된 이슈 번호
Closes #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알람 장소 등록에 Google Place ID와 선택적 세션 토큰을 지원합니다.
  * Google 장소 정보와 위치 캐시를 자동으로 갱신합니다.
  * 만료된 위치 캐시를 주기적으로 정리합니다.
  * 사전 알림 정보에 알람 식별자가 포함됩니다.

* **개선 사항**
  * 위치 캐시가 없거나 만료된 경우에도 최신 주소 정보를 제공합니다.
  * 장소 재선택이 필요한 상황에 명확한 오류 안내를 제공합니다.
  * Google 장소 관련 민감 정보가 로그에서 안전하게 마스킹됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->