### PR TITLE
[#135] ✨ FCM 테스트 푸시 API 추가

### DIFF
--- a/src/main/java/akuma/whiplash/global/config/security/RequestMatcherHolder.java
+++ b/src/main/java/akuma/whiplash/global/config/security/RequestMatcherHolder.java
@@ -45,10 +45,10 @@ public class RequestMatcherHolder {
         new RequestInfo(GET, "/webjars/**",null),
         new RequestInfo(GET, "/favicon.ico",null),
 
-        // 부하 테스트 전용 (profile: !prod) — prod에서는 Controller Bean 자체가 생성되지 않음
-        new RequestInfo(GET, "/api/load-test/**", null),
-        new RequestInfo(POST, "/api/load-test/**", null),
-        new RequestInfo(DELETE, "/api/load-test/**", null),
+        // local·qa 전용 테스트 API
+        new RequestInfo(GET, "/api/v1/test/**", null),
+        new RequestInfo(POST, "/api/v1/test/**", null),
+        new RequestInfo(DELETE, "/api/v1/test/**", null),
 
         // alarm
         new RequestInfo(GET, "/api/v1/alarms/**",USER),

--- a/src/main/java/akuma/whiplash/infrastructure/firebase/MockTestFcmService.java
+++ b/src/main/java/akuma/whiplash/infrastructure/firebase/MockTestFcmService.java
@@ -1,0 +1,23 @@
+package akuma.whiplash.infrastructure.firebase;
+
+import akuma.whiplash.infrastructure.firebase.dto.FcmMetricResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Primary
+@Profile("local")
+public class MockTestFcmService extends TestFcmService {
+
+    @Override
+    public FcmMetricResult createTestNotification(String token, String title, String body, String deeplink) {
+        log.info("[MockTestFcmService] createTestNotification called");
+        return FcmMetricResult.builder()
+            .successCount(token.startsWith("INVALID") ? 0 : 1)
+            .failedCount(token.startsWith("INVALID") ? 1 : 0)
+            .build();
+    }
+}

--- a/src/main/java/akuma/whiplash/infrastructure/firebase/TestFcmService.java
+++ b/src/main/java/akuma/whiplash/infrastructure/firebase/TestFcmService.java
@@ -1,0 +1,58 @@
+package akuma.whiplash.infrastructure.firebase;
+
+import akuma.whiplash.infrastructure.firebase.dto.FcmMetricResult;
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+import java.time.Duration;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Profile("qa")
+public class TestFcmService {
+
+    public FcmMetricResult createTestNotification(
+        String token,
+        String title,
+        String body,
+        String deeplink
+    ) {
+        MulticastMessage message = MulticastMessage.builder()
+            .addToken(token)
+            .putAllData(Map.of("title", title, "body", body, "deeplink", deeplink))
+            .setAndroidConfig(AndroidConfig.builder()
+                .setPriority(AndroidConfig.Priority.HIGH)
+                .setTtl(Duration.ofMinutes(5).toMillis())
+                .build())
+            .setApnsConfig(ApnsConfig.builder()
+                .putHeader("apns-push-type", "alert")
+                .putHeader("apns-priority", "10")
+                .setAps(Aps.builder()
+                    .setAlert(ApsAlert.builder().setTitle(title).setBody(body).build())
+                    .setSound("default")
+                    .build())
+                .build())
+            .build();
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            return FcmMetricResult.builder()
+                .successCount(response.getSuccessCount())
+                .failedCount(response.getFailureCount())
+                .build();
+        } catch (FirebaseMessagingException e) {
+            log.warn("테스트 FCM 전송 실패: error={}", e.getErrorCode());
+            return FcmMetricResult.builder().successCount(0).failedCount(1).build();
+        }
+    }
+
+}

--- a/src/main/java/akuma/whiplash/loadtest/application/dto/request/TestPushRequest.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/dto/request/TestPushRequest.java
@@ -1,0 +1,23 @@
+package akuma.whiplash.loadtest.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "테스트 FCM 푸시 전송 요청 DTO")
+public record TestPushRequest(
+    @Schema(description = "전송할 FCM 토큰", example = "fcm-token")
+    @NotBlank(message = "FCM 토큰을 입력해주세요.")
+    String fcmToken,
+
+    @Schema(description = "알림 제목", example = "테스트 알림")
+    @NotBlank(message = "푸시 제목을 입력해주세요.")
+    String title,
+
+    @Schema(description = "알림 본문", example = "푸시가 정상 도착했습니다.")
+    @NotBlank(message = "푸시 본문을 입력해주세요.")
+    String body,
+
+    @Schema(description = "앱 딥링크", example = "nuntteo://main")
+    @NotBlank(message = "딥링크를 입력해주세요.")
+    String deeplink
+) {}

--- a/src/main/java/akuma/whiplash/loadtest/application/dto/response/TestPushResponse.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/dto/response/TestPushResponse.java
@@ -1,0 +1,12 @@
+package akuma.whiplash.loadtest.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "테스트 FCM 푸시 전송 결과 DTO")
+public record TestPushResponse(
+    @Schema(description = "FCM 전송 성공 건수", example = "1")
+    int successCount,
+
+    @Schema(description = "FCM 전송 실패 건수", example = "0")
+    int failedCount
+) {}

--- a/src/main/java/akuma/whiplash/loadtest/application/service/TestPushService.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/service/TestPushService.java
@@ -1,0 +1,9 @@
+package akuma.whiplash.loadtest.application.service;
+
+import akuma.whiplash.loadtest.application.dto.request.TestPushRequest;
+import akuma.whiplash.infrastructure.firebase.dto.FcmMetricResult;
+
+public interface TestPushService {
+
+    FcmMetricResult createTestPush(TestPushRequest request);
+}

--- a/src/main/java/akuma/whiplash/loadtest/application/service/TestPushServiceImpl.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/service/TestPushServiceImpl.java
@@ -1,0 +1,22 @@
+package akuma.whiplash.loadtest.application.service;
+
+import akuma.whiplash.infrastructure.firebase.TestFcmService;
+import akuma.whiplash.infrastructure.firebase.dto.FcmMetricResult;
+import akuma.whiplash.loadtest.application.dto.request.TestPushRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Profile({"local", "qa"})
+@Service
+@RequiredArgsConstructor
+public class TestPushServiceImpl implements TestPushService {
+
+    private final TestFcmService testFcmService;
+
+    @Override
+    public FcmMetricResult createTestPush(TestPushRequest request) {
+        return testFcmService.createTestNotification(
+            request.fcmToken(), request.title(), request.body(), request.deeplink());
+    }
+}

--- a/src/main/java/akuma/whiplash/loadtest/application/usecase/FcmTokenLoadTestUseCase.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/usecase/FcmTokenLoadTestUseCase.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service;
  *
  * 검증 방법:
  *   동일 memberId, 동일 deviceId에 대해 여러 VU가 동시에 다른 토큰을 등록한 뒤
- *   GET /api/load-test/fcm-token/verify/{memberId} 로 tokenCount를 확인한다.
+ *   GET /api/v1/test/fcm-token/verify/{memberId} 로 tokenCount를 확인한다.
  *   - AS-IS: tokenCount > 1 (stale token 잔류 가능)
  *   - TO-BE: tokenCount == 1 (항상 마지막 토큰만 유지)
  */

--- a/src/main/java/akuma/whiplash/loadtest/application/usecase/TestPushUseCase.java
+++ b/src/main/java/akuma/whiplash/loadtest/application/usecase/TestPushUseCase.java
@@ -1,0 +1,22 @@
+package akuma.whiplash.loadtest.application.usecase;
+
+import akuma.whiplash.global.annotation.architecture.UseCase;
+import akuma.whiplash.infrastructure.firebase.dto.FcmMetricResult;
+import akuma.whiplash.loadtest.application.dto.request.TestPushRequest;
+import akuma.whiplash.loadtest.application.dto.response.TestPushResponse;
+import akuma.whiplash.loadtest.application.service.TestPushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"local", "qa"})
+@UseCase
+@RequiredArgsConstructor
+public class TestPushUseCase {
+
+    private final TestPushService testPushService;
+
+    public TestPushResponse createTestPush(TestPushRequest request) {
+        FcmMetricResult result = testPushService.createTestPush(request);
+        return new TestPushResponse(result.getSuccessCount(), result.getFailedCount());
+    }
+}

--- a/src/main/java/akuma/whiplash/loadtest/presentation/TestController.java
+++ b/src/main/java/akuma/whiplash/loadtest/presentation/TestController.java
@@ -1,12 +1,18 @@
 package akuma.whiplash.loadtest.presentation;
 
+import akuma.whiplash.global.annotation.swagger.CustomErrorCodes;
 import akuma.whiplash.global.response.ApplicationResponse;
 import akuma.whiplash.loadtest.application.usecase.AlarmPipelineLoadTestUseCase;
 import akuma.whiplash.loadtest.application.usecase.FcmBulkSendLoadTestUseCase;
 import akuma.whiplash.loadtest.application.usecase.FcmTokenLoadTestUseCase;
+import akuma.whiplash.loadtest.application.usecase.TestPushUseCase;
+import akuma.whiplash.loadtest.application.dto.request.TestPushRequest;
+import akuma.whiplash.loadtest.application.dto.response.TestPushResponse;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,29 +26,29 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 부하 테스트 전용 컨트롤러
  *
- * @Profile("!prod") — prod 환경에서는 Bean 자체가 생성되지 않아 엔드포인트가 노출되지 않는다.
+ * @Profile({"local", "qa"}) — local·QA 환경에서만 Bean이 생성된다.
  *
  * 3가지 개선 사례에 대한 AS-IS / TO-BE 비교 엔드포인트를 하나의 컨트롤러에 통합한다:
- *   - /api/load-test/fcm-bulk/**      사례 1. FCM 대량 발송 최적화
- *   - /api/load-test/alarm-pipeline/** 사례 2. 알람 파이프라인 멱등성 및 재시도
- *   - /api/load-test/fcm-token/**     사례 3. Redis 다중 디바이스 FCM 토큰 관리
+ *   - /api/v1/test/fcm-bulk/**      사례 1. FCM 대량 발송 최적화
+ *   - /api/v1/test/alarm-pipeline/** 사례 2. 알람 파이프라인 멱등성 및 재시도
+ *   - /api/v1/test/fcm-token/**     사례 3. Redis 다중 디바이스 FCM 토큰 관리
  */
-@Profile("!prod")
+@Profile({"local", "qa"})
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/load-test")
-public class LoadTestController {
+public class TestController {
 
     private final FcmBulkSendLoadTestUseCase fcmBulkUseCase;
     private final AlarmPipelineLoadTestUseCase alarmPipelineUseCase;
     private final FcmTokenLoadTestUseCase fcmTokenUseCase;
+    private final TestPushUseCase testPushUseCase;
 
     // =========================================================================
-    // 사례 1. FCM 대량 발송 최적화  (/api/load-test/fcm-bulk)
+    // 사례 1. FCM 대량 발송 최적화  (/api/v1/test/fcm-bulk)
     // =========================================================================
 
     /** 테스트 회원 생성 + 각 회원에 FCM 토큰 등록 */
-    @PostMapping("/fcm-bulk/setup")
+    @PostMapping("/api/v1/test/fcm-bulk/setup")
     public ApplicationResponse<FcmBulkSendLoadTestUseCase.SetupResponse> fcmBulkSetup(
         @RequestParam(defaultValue = "10") int memberCount,
         @RequestParam(defaultValue = "3") int tokensPerMember
@@ -54,7 +60,7 @@ public class LoadTestController {
      * AS-IS: 토큰 1건씩 순차 전송 시뮬레이션
      * totalMs ≈ tokenCount × fcmLatencyMs
      */
-    @PostMapping("/fcm-bulk/send-sequential")
+    @PostMapping("/api/v1/test/fcm-bulk/send-sequential")
     public ApplicationResponse<FcmBulkSendLoadTestUseCase.SendResponse> fcmBulkSendSequential(
         @RequestParam List<Long> memberIds,
         @RequestParam(defaultValue = "1") int iterations,
@@ -67,7 +73,7 @@ public class LoadTestController {
      * TO-BE: 500건 배치 + 병렬 전송 시뮬레이션
      * totalMs ≈ ceil(tokenCount / 500) × fcmLatencyMs
      */
-    @PostMapping("/fcm-bulk/send-batch")
+    @PostMapping("/api/v1/test/fcm-bulk/send-batch")
     public ApplicationResponse<FcmBulkSendLoadTestUseCase.SendResponse> fcmBulkSendBatch(
         @RequestParam List<Long> memberIds,
         @RequestParam(defaultValue = "1") int iterations,
@@ -77,7 +83,7 @@ public class LoadTestController {
     }
 
     /** 테스트 회원 + Redis 토큰 정리 */
-    @DeleteMapping("/fcm-bulk/cleanup")
+    @DeleteMapping("/api/v1/test/fcm-bulk/cleanup")
     public ApplicationResponse<String> fcmBulkCleanup(
         @RequestParam List<Long> memberIds,
         @RequestParam(defaultValue = "3") int tokensPerMember
@@ -87,11 +93,11 @@ public class LoadTestController {
     }
 
     // =========================================================================
-    // 사례 2. 알람 파이프라인 — 배치 멱등성 및 재시도  (/api/load-test/alarm-pipeline)
+    // 사례 2. 알람 파이프라인 — 배치 멱등성 및 재시도  (/api/v1/test/alarm-pipeline)
     // =========================================================================
 
     /** 테스트 회원 생성 + 각 회원에 알람 1개 생성 */
-    @PostMapping("/alarm-pipeline/setup")
+    @PostMapping("/api/v1/test/alarm-pipeline/setup")
     public ApplicationResponse<AlarmPipelineLoadTestUseCase.SetupResponse> alarmPipelineSetup(
         @RequestParam(defaultValue = "5") int memberCount
     ) {
@@ -103,7 +109,7 @@ public class LoadTestController {
      * 2번째+ 시도: DataIntegrityViolationException → failed 카운트 증가
      * (date 파라미터: 동일 date 재사용 시 unique constraint 충돌 발생)
      */
-    @PostMapping("/alarm-pipeline/create-occurrences-no-guard")
+    @PostMapping("/api/v1/test/alarm-pipeline/create-occurrences-no-guard")
     public ApplicationResponse<AlarmPipelineLoadTestUseCase.BatchResult> alarmPipelineCreateNoGuard(
         @RequestParam List<Long> memberIds,
         @RequestParam LocalDate date,
@@ -118,7 +124,7 @@ public class LoadTestController {
      * 2번째+ 시도: existingIds 체크로 skip → skipped 카운트 증가
      * (date 파라미터: AS-IS와 다른 날짜를 사용해야 독립 측정 가능)
      */
-    @PostMapping("/alarm-pipeline/create-occurrences")
+    @PostMapping("/api/v1/test/alarm-pipeline/create-occurrences")
     public ApplicationResponse<AlarmPipelineLoadTestUseCase.BatchResult> alarmPipelineCreate(
         @RequestParam List<Long> memberIds,
         @RequestParam LocalDate date,
@@ -129,7 +135,7 @@ public class LoadTestController {
     }
 
     /** 테스트 occurrence + alarm + member 정리 */
-    @DeleteMapping("/alarm-pipeline/cleanup")
+    @DeleteMapping("/api/v1/test/alarm-pipeline/cleanup")
     public ApplicationResponse<String> alarmPipelineCleanup(
         @RequestParam List<Long> memberIds
     ) {
@@ -138,11 +144,11 @@ public class LoadTestController {
     }
 
     // =========================================================================
-    // 사례 3. Redis 다중 디바이스 FCM 토큰 관리  (/api/load-test/fcm-token)
+    // 사례 3. Redis 다중 디바이스 FCM 토큰 관리  (/api/v1/test/fcm-token)
     // =========================================================================
 
     /** 테스트 회원 생성 */
-    @PostMapping("/fcm-token/setup")
+    @PostMapping("/api/v1/test/fcm-token/setup")
     public ApplicationResponse<FcmTokenLoadTestUseCase.SetupResponse> fcmTokenSetup(
         @RequestParam(defaultValue = "2") int memberCount
     ) {
@@ -153,7 +159,7 @@ public class LoadTestController {
      * AS-IS: 비원자적 토큰 등록 (트랜잭션 없이 개별 Redis 명령 실행)
      * 동시 요청 시 stale token 잔류 가능
      */
-    @PostMapping("/fcm-token/register-non-atomic")
+    @PostMapping("/api/v1/test/fcm-token/register-non-atomic")
     public ApplicationResponse<FcmTokenLoadTestUseCase.RegisterResponse> fcmTokenRegisterNonAtomic(
         @RequestBody TokenRegisterRequest request
     ) {
@@ -165,7 +171,7 @@ public class LoadTestController {
      * TO-BE: MULTI/EXEC 원자적 토큰 등록
      * old token 정리 + new token 등록이 원자적으로 처리됨
      */
-    @PostMapping("/fcm-token/register-atomic")
+    @PostMapping("/api/v1/test/fcm-token/register-atomic")
     public ApplicationResponse<FcmTokenLoadTestUseCase.RegisterResponse> fcmTokenRegisterAtomic(
         @RequestBody TokenRegisterRequest request
     ) {
@@ -174,7 +180,7 @@ public class LoadTestController {
     }
 
     /** 특정 회원의 현재 FCM 토큰 수와 목록 조회 (AS-IS/TO-BE 결과 검증용) */
-    @GetMapping("/fcm-token/verify/{memberId}")
+    @GetMapping("/api/v1/test/fcm-token/verify/{memberId}")
     public ApplicationResponse<FcmTokenLoadTestUseCase.VerifyResponse> fcmTokenVerify(
         @PathVariable Long memberId
     ) {
@@ -182,12 +188,19 @@ public class LoadTestController {
     }
 
     /** 테스트 회원 + Redis 토큰 키 정리 */
-    @DeleteMapping("/fcm-token/cleanup")
+    @DeleteMapping("/api/v1/test/fcm-token/cleanup")
     public ApplicationResponse<String> fcmTokenCleanup(
         @RequestParam List<Long> memberIds
     ) {
         fcmTokenUseCase.cleanup(memberIds);
         return ApplicationResponse.onSuccess("cleanup completed");
+    }
+
+    @CustomErrorCodes
+    @Operation(summary = "FCM 테스트 푸시 전송", description = "local·qa 환경에서 지정한 FCM 토큰에 테스트 푸시를 전송합니다.")
+    @PostMapping("/api/v1/test/fcm/push")
+    public ApplicationResponse<TestPushResponse> createTestPush(@RequestBody @Valid TestPushRequest request) {
+        return ApplicationResponse.onSuccess(testPushUseCase.createTestPush(request));
     }
 
     // ===== Request Records =====

--- a/src/test/java/akuma/whiplash/loadtest/presentation/TestControllerTest.java
+++ b/src/test/java/akuma/whiplash/loadtest/presentation/TestControllerTest.java
@@ -1,0 +1,86 @@
+package akuma.whiplash.loadtest.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import akuma.whiplash.global.config.security.SecurityConfig;
+import akuma.whiplash.global.config.security.jwt.JwtAuthenticationFilter;
+import akuma.whiplash.loadtest.application.usecase.AlarmPipelineLoadTestUseCase;
+import akuma.whiplash.loadtest.application.usecase.FcmBulkSendLoadTestUseCase;
+import akuma.whiplash.loadtest.application.usecase.FcmTokenLoadTestUseCase;
+import akuma.whiplash.loadtest.application.usecase.TestPushUseCase;
+import akuma.whiplash.loadtest.application.dto.request.TestPushRequest;
+import akuma.whiplash.loadtest.application.dto.response.TestPushResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("local")
+@DisplayName("TestController Slice Test")
+@WebMvcTest(
+    controllers = TestController.class,
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        SecurityConfig.class, JwtAuthenticationFilter.class
+    })
+)
+@AutoConfigureMockMvc(addFilters = false)
+class TestControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean private TestPushUseCase testPushUseCase;
+    @MockitoBean private FcmBulkSendLoadTestUseCase fcmBulkUseCase;
+    @MockitoBean private AlarmPipelineLoadTestUseCase alarmPipelineUseCase;
+    @MockitoBean private FcmTokenLoadTestUseCase fcmTokenUseCase;
+
+    @Nested
+    @DisplayName("[POST] /api/v1/test/fcm/push - FCM 테스트 푸시 전송")
+    class SendTestPushTest {
+
+        @Test
+        @DisplayName("성공: FCM 전송 결과를 반환한다")
+        void success() throws Exception {
+            // given
+            TestPushRequest request = new TestPushRequest("direct-fcm-token", "테스트", "도착 확인", "nuntteo://main");
+            when(testPushUseCase.createTestPush(any(TestPushRequest.class)))
+                .thenReturn(new TestPushResponse(1, 0));
+
+            // when
+            // then
+            mockMvc.perform(post("/api/v1/test/fcm/push")
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.successCount").value(1))
+                .andExpect(jsonPath("$.result.failedCount").value(0));
+        }
+
+        @Test
+        @DisplayName("실패: title이 공백이면 400을 반환한다")
+        void fail_titleBlank() throws Exception {
+            // given
+            TestPushRequest request = new TestPushRequest("direct-fcm-token", "", "도착 확인", "nuntteo://main");
+
+            // when
+            // then
+            mockMvc.perform(post("/api/v1/test/fcm/push")
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

로컬·QA 환경에서 앱 개발자가 사용자 인증이나 저장된 기기 토큰에 의존하지 않고, 요청 본문의 FCM 토큰과 메시지 정보로 단일 기기 푸시 수신을 검증할 수 있습니다.

## 변경 사항

- 기존 부하 테스트 경로를 `/api/v1/test/**`로 통합해 테스트 API의 진입점을 일관되게 정리했습니다.
- 테스트 푸시 전송을 전용 UseCase·Service·FCM 구현으로 분리해 일반 알림 전송 흐름과 독립적으로 검증합니다.
- local에서는 모의 전송 결과를 반환하고 QA에서는 실제 FCM을 호출하며, 두 환경에서만 컨트롤러가 노출됩니다.
- `/api/v1/test/**`는 인증 없이 호출할 수 있어 앱 개발자가 테스트 토큰으로 즉시 확인할 수 있습니다.

## Test

- `./gradlew test --tests akuma.whiplash.loadtest.presentation.TestControllerTest`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로컬·QA 환경에서 FCM 테스트 푸시를 전송하고 성공·실패 건수를 확인할 수 있습니다.
  * 테스트 푸시 요청의 필수값 검증을 지원합니다.
  * 테스트 관련 API를 `/api/v1/test` 경로로 제공합니다.
* **변경 사항**
  * 기존 부하 테스트 API 경로가 새로운 테스트 API 경로로 통합되었습니다.
  * 테스트 API는 운영 환경에서 비활성화됩니다.
* **버그 수정**
  * 잘못된 입력에 대해 HTTP 400 오류가 반환되도록 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->